### PR TITLE
[250212] 웨디

### DIFF
--- a/weadie/1967.py
+++ b/weadie/1967.py
@@ -1,0 +1,50 @@
+import sys
+
+n = int(input())
+
+graph = [[] for _ in range(n + 1)]
+
+for _ in range(n - 1):
+    a, b, c = map(int, input().split())
+    
+    graph[a].append((b, c))
+    graph[b].append((a, c))
+    
+
+def far(start):
+    maxNode = None
+    maxCost = float('-inf')
+    visited = [False] * (n + 1)
+
+    s = []
+    s.append((start, 0)) # 시작과 코스트
+    visited[start] = True
+    
+    while len(s) > 0:
+        node, cost = s.pop()
+        
+        for v in graph[node]:
+            nextNode, nextCost = v
+                
+            if not visited[nextNode]:
+                s.append((nextNode, nextCost + cost))
+                
+                if maxCost < nextCost + cost:
+                    maxCost = nextCost + cost
+                    maxNode = nextNode
+
+                visited[nextNode] = True
+                
+            
+    return(maxNode, maxCost)
+
+if n == 1:
+    print(0)
+    sys.exit(0)
+    
+p1, cost1 = far(1)
+
+p2, cost2 = far(p1)
+
+print(cost2)
+


### PR DESCRIPTION
## 🏷️ 백준번호
- [1967](https://www.acmicpc.net/problem/1967)

## ✏️ 풀이방법
1줄요약: 트리의 지름을 구하는 명확한 방법을 사용한다.

바로 생각나고 간단하게 풀 수 있는 방법인 플로이드를 썼으나 메모리 초과가 났다. 
n이 10^4라서 당연하다.

트리의 지름을 찾는 명확한 방볍을 사용하는게 탈출구다.

방법은 3스텝이다.
1. 임의의 노드에서 가장 먼 노드 a를 찾는다.
2. a에서 가장 먼 노드 b를 찾는다
3. a와 b사이의 거리가 트리의 지름이다. 

임의의 노드를 잡아 a를 특정하고 거기서 가장 긴 b를 특정하여 a와 b의 거리가 트리의 지름이 된다는게 직관적으로 납득이 되지 않았다. 
그래서 저 공식의 반례 존재 가능성을 찾으며 납득하기로 했다.

지름의 정의는 한 점에서 다른 점까지의 거리가 가장 긴 것. 즉 지름이 x-y라면 x에서 가장 먼 점은 y라는 자명한 사실.

1. 진짜 지름인 x-y를 제치고 더 긴 지름인 a-b의 존재 가능성
x-y, a-b모두 z라는 중심점을 지난다고 하자. 그러면 x-z-y, a-z-b가 된다. 지름의 길이는 x-z + z-y ,a-z + z+b이다. x에서 가장 먼 점이 y일 때 x-y가 지름이 된다. 이떄 더 긴 지름이 나오기 위해선 z-b 길이 > z-y 길이 여야함. 그렇게 되면 x에서 가장 먼 점이 y가 아니라 b가된다. 그렇다는건 y라는 점은 존재자체가 불가능하다는 것. 즉, x-y를 제친 더 긴 지름이 존재할 가능성은 없다.

2. 진짜 지름 x-y와 더 긴 지름인 a-b 선분이 중간에 다리를 하나 두고 이어져있을 때의 a-b의 존재 가능성
1번과 매우 유사하다. x-y에 있는 다리점을 g1, a-b에 있는 다리점을 g2라고 하자. 더 긴 지름인 a-b 이 존재할 수 있으려면 g2-b > g1-g2 + g1-y가 성립해야한다. 그러나 이게 성립하면 x에서 가장 먼 점이 y가 아니게 된다. 고로 불가능

3. 진짜 지름과 아예 접점이 없으면서 더 긴 지름인 a-b 존재 가능성
트리는 다 이어져있으므로 불가능

그래서 3스텝의 공식을 납득하게 되었고, 임의 노드로부터 가장 먼 노드는 다익이나 dfs로 찾을 수 있다.

## ⏰ 시간복잡도
두번의 dfs이므로 2*(10^4) 
