### PR TITLE
[250213] 웨디

### DIFF
--- a/weadie/1967.py
+++ b/weadie/1967.py
@@ -1,0 +1,50 @@
+import sys
+
+n = int(input())
+
+graph = [[] for _ in range(n + 1)]
+
+for _ in range(n - 1):
+    a, b, c = map(int, input().split())
+    
+    graph[a].append((b, c))
+    graph[b].append((a, c))
+    
+
+def far(start):
+    maxNode = None
+    maxCost = float('-inf')
+    visited = [False] * (n + 1)
+
+    s = []
+    s.append((start, 0)) # 시작과 코스트
+    visited[start] = True
+    
+    while len(s) > 0:
+        node, cost = s.pop()
+        
+        for v in graph[node]:
+            nextNode, nextCost = v
+                
+            if not visited[nextNode]:
+                s.append((nextNode, nextCost + cost))
+                
+                if maxCost < nextCost + cost:
+                    maxCost = nextCost + cost
+                    maxNode = nextNode
+
+                visited[nextNode] = True
+                
+            
+    return(maxNode, maxCost)
+
+if n == 1:
+    print(0)
+    sys.exit(0)
+    
+p1, cost1 = far(1)
+
+p2, cost2 = far(p1)
+
+print(cost2)
+

--- a/weadie/2206.md
+++ b/weadie/2206.md
@@ -1,0 +1,122 @@
+'''
+10
+
+재귀 dfs로 그래프를 업데이트하고 회귀하며 전달한다.
+'''
+
+'''
+visited를 복제해서 쓰는게 좋겠음. 
+
+'''
+
+from collections import deque
+import sys
+sys.setrecursionlimit(10**6)
+
+EMPTY = 0
+WALL = 1
+VISITED = -1
+
+row, col = map(int, input().split())
+graph = [[] for _ in range(row)]
+
+for i in range(row):
+    line = input()
+
+    for j in range(col):
+        graph[i].append(int(line[j]))
+
+def isGoal(y, x):
+    return y == row - 1 and x == col - 1
+
+def isOutOfRange(y, x):
+    return y >= row or y < 0 or x >= col or x < 0
+
+def printGraph(grpah):
+    for y in range(row):
+        print(' '.join(map(str, graph[y])))
+
+def printVisited(g):
+    for y in range(row):
+        r = []
+        for x in range(col):
+            if g[y][x] == float('inf'):
+                r.append('0')
+            else:
+                r.append(g[y][x])
+
+        print(' '.join(map(str, r)))
+        
+minDist = float('inf')
+        
+DX = [0, 1, 0, -1]
+DY = [1, 0, -1, 0]
+
+def copy(g):
+    a = []
+    for y in range(len(g)):
+        r = []
+        for x in range(len(g[0])):
+            r.append(g[y][x])
+        a.append(r)
+
+    return a
+
+def bfsMove(graph):
+    global minDist
+    
+    q = deque()
+    dist = [[[float('inf')] * col for _ in range(row)] for _ in range(2)] # inf면 낫비짓
+    dist[0][0][0] = 1
+    dist[1][0][0] = 1
+    
+    q.append((0, 0, False)) # y, x, 부수기 위치
+
+    while len(q) > 0:
+        y, x, isPunch = q.popleft()
+
+        if isGoal(y, x):
+            minDist = min(minDist, dist[0][y][x], dist[1][y][x])
+            continue
+
+        for i in range(len(DX)):
+            ny, nx = y + DY[i], x + DX[i]
+            
+            if isOutOfRange(ny, nx):
+                continue
+
+            if not isPunch and dist[0][ny][nx] != float('inf') and dist[0][y][x] + 1 >= dist[0][ny][nx]:
+                continue
+
+            if isPunch and dist[1][ny][nx] != float('inf') and dist[1][y][x] + 1 >= dist[1][ny][nx]:
+                continue
+
+            # 이미 펀치 했는데 또 벽만날 경우 pass
+            if isPunch and graph[ny][nx] == WALL:
+                continue
+
+            if not isPunch and graph[ny][nx] == WALL:
+                dist[1][ny][nx] = dist[1][y][x] + 1
+                q.append((ny, nx, True))
+            else:
+                if isPunch:
+                    dist[1][ny][nx] = dist[1][y][x] + 1
+                    q.append((ny, nx, isPunch))
+                else:
+                    dist[0][ny][nx] = dist[0][y][x] + 1
+                    dist[1][ny][nx] = dist[1][y][x] + 1
+                    
+                    q.append((ny, nx, isPunch))
+
+
+graph[0][0] = VISITED
+if row == 1 and col == 1:
+    print(1)
+    sys.exit(0)
+    
+bfsMove(graph)
+
+print(minDist if minDist != float('inf') else -1)
+
+    
+


### PR DESCRIPTION
## 🏷️ 백준번호
- [2206](https://www.acmicpc.net/problem/2206)

## ✏️ 풀이방법
여러 접근을 해봄

### 1번 접근
재귀 dfs. 펀치하면 WALL을 EMPTY로 바꾸고 되돍아오면 다시 원복시키는 형태.
오답 이유는 애초에 최단거리인데 dfs를 사용하면 안됐음. 벽을 부수고 원복시킨다 => 재귀 => dfs가 되어버림

문제를 잘 읽자.

### 2번 접근
bfs.
하나의 dist배열을 사용한 것이 문제다. 
출발지에는 벽을 부수면 도착지점 "주위"까지 더 빠르게 도착할 수 있는 지름길과 도착지 주변은 모두 벽으로 감싸져있어 부수지 않으면 도착할 수 없는 상황이라고 가정해보자. 이때는 지름길을 택해 벽을 부순 경우, 벽을 부수지 않은 경우의 거리보다 짧기 때문에 dist에는 벽을 부수고 갈 때의 dist가 사용된다. 즉, 벽을 부수지않은 경우가 가지치기 당하는것! 결과적으로는 도착지점 주변의 벽을 부술 수 없어 탈출할 수 없다는 답이 나온다.

### 3번 접근
벽을 부쉈을 때는 벽을 부수지 않았을 때와 다른 dist를 갖는다. 
그래서 벽을 부쉈을 때는 dist배열을 깊은복사해 큐에 append하여 독립적인 dist를 사용하도록 했다. 
이렇게 구현할 경우 bfs가 최악의 경우 칸수만큼 자가복제 되어 시간초과가 발생할 수 있다. 벽을 부술 때마다 독자적인 dist를 사용하려고 하기 때문

### 4번 접근
2에서 말한 예를 확장해서 생각해보자면, 도착지 주변이 부수지않으면 도착 못할 벽이 있을 수도 없을 수도 있다. 즉 지름길을 사용하는 것 자체를 막는 방법은 사용할 수 없다. 지름길을 사용하는 방법은 도착지 주변이 빈 칸일 경우 최단거리가 되기 때문.. 그러니 지름길을 위해 벽을 부수던, 지름길을 안쓰고 돌아가던 두 정보가 모두 유의미한 정보로 보관되어야 한다. 

그래서 벽을 부순 경우, 벽을 부수지 않은 경우 둘 다를 dist에 업데이트 한다. 즉 3차원 배열을 사용한다.
```python
dist = [[[float('inf')] * col for _ in range(row)] for _ in range(2)]
````
펀치 이후라면 z=1의 dist를 업데이트하고, 펀치 전이면 z=0, z=1을 모두 업데이트 한다. 펀치 전에 z=0만 업데이트하면, 도착지점 근처에만 벽이 있을 경우 벽에 도달할 때 까지의 벽dist가 다 inf라서 유효한 값을 가져와 갱신할 수 없기 때문이다. 

## ⏰ 시간복잡도
row*col

## 깨달음
1. 백준의 퍼센트, 문제 수정량은 반비례가 아니다. 너무 비약이다. 퍼센트가 높게 떴다고 해도 아예 잘못된 코드일 수 있다.
2. 문제를 읽고 충분히 머릿속에서 시뮬레이션하며 가능성을 본 후 작성해라.
