### PR TITLE
[250214] 쿠키 (벽 부수고 이동하기)

### DIFF
--- a/cookie/2206.js
+++ b/cookie/2206.js
@@ -1,0 +1,79 @@
+class Queue {
+  constructor() {
+    this.storage = new Object();
+    this.front = 0;
+    this.rear = 0;
+  }
+
+  size() {
+    return this.rear - this.front;
+  }
+
+  enqueue(element) {
+    this.storage[this.rear] = element;
+    this.rear++;
+  }
+
+  dequeue() {
+    let removed = this.storage[this.front];
+    delete this.storage[this.front];
+    this.front++;
+
+    if (this.front === this.rear) {
+      this.front = 0;
+      this.rear = 0;
+    }
+
+    return removed;
+  }
+}
+
+const fs = require("fs");
+const [input, ...rest] = fs.readFileSync(0, "utf8").trim().split("\n");
+
+const [n, m] = input.split(" ").map(Number);
+const matrix = rest.map((row) => row.split("").map(Number));
+const visited = Array.from({ length: n }, () => Array.from({ length: m }, () => [0, 0]));
+const directions = [
+  [-1, 0],
+  [1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+const bfs = (startX, startY) => {
+  const queue = new Queue();
+  queue.enqueue([startX, startY, 0]);
+  visited[startX][startY][0] = 1;
+
+  while (queue.size() > 0) {
+    const [x, y, isPunch] = queue.dequeue();
+
+    if (x === n - 1 && y === m - 1) {
+      return visited[x][y][isPunch];
+    }
+
+    for (const [dx, dy] of directions) {
+      const nx = x + dx;
+      const ny = y + dy;
+
+      // 방문하지 않은 유효한 점
+      if (nx >= 0 && nx < n && ny >= 0 && ny < m && visited[nx][ny][isPunch] === 0) {
+        const nextDistance = visited[nx][ny][isPunch] + 1;
+        // 0이라면
+        if (matrix[nx][ny] === 0 && (visited[nx][ny][isPunch] === 0 || visited[nx][ny][isPunch] > nextDistance)) {
+          visited[nx][ny][isPunch] = visited[x][y][isPunch] + 1;
+          queue.enqueue([nx, ny, isPunch]);
+          // 1이지만 벽을 부수지 않았다면
+        } else if (matrix[nx][ny] === 1 && isPunch === 0 && visited[nx][ny][1] === 0) {
+          visited[nx][ny][1] = visited[x][y][0] + 1;
+          queue.enqueue([nx, ny, 1]);
+        }
+      }
+    }
+  }
+
+  return -1;
+};
+
+console.log(bfs(0, 0));


### PR DESCRIPTION
## 🏷️ 백준번호
- [2206](https://www.acmicpc.net/problem/2206)

## ✏️ 풀이방법
시간 초과와 벽을 부수고 지름길로 가는 루트가 정상적으로 가는 루트를 막지 않게 하는 방법이 정말 어려웠던 문제이다.
시간 초과가 난 원인을 살펴보면 queue의 문제였다. js에서는 queue를 제공하지 않기 때문에 쉽게 queue를 리스트 메서드를 사용해서 구현했었다. (pop은 shift, push는 push) 그러나 shift 연산은 배열의 첫 번째 요소를 제거한 뒤, 나머지 요소를 앞으로 한 칸씩 당기게 되어 O(N)의 시간이 걸리기 때문에 시간이 길어지게 된다. 이번에는 입력이 커서 배열의 shift, pop으로 다 커버 할 수가 없기 때문에 직접 Queue를 구현해서 사용해야 했다.

벽을 부수고 지름길로 가는 루트가 정상적으로 가는 루트를 막지 않게 하는 방법
이 방법을 떠올리기가 너무 어려웠다. 처음에는 벽을 부수는 것을 boolean으로 생각하고 벽을 부쉈다면 다음에는 벽을 부수지 못 하도록 제한을 두었다. 하지만 이런 경우에는 벽을 부순 뒤에 진행할 수 없는 루트가 있을 때, 다른 루트로 진행할 수 있는 길을 막아버린다... 그래서 구할 수가 없었고 여기서 부쉈을 때와 부수지 않았을 때 두 가지를 생각해야 한다는 조언을 듣게 되었다.

그래서 3차원 배열을 사용하게 됐다.
```js
visited[x][y][0] // 벽을 부수지 않고 도달한 최단 거리
visited[x][y][1] // 벽을 부순 뒤 도달한 최단 거리
```

이렇게 두 경우의 수를 나누고 다음 탐색 결과가 0이라면 이전의 +1을 해주고, 큐에 넣어주며 
```js
visited[nx][ny][isPunch] = visited[x][y][isPunch] + 1;
queue.enqueue([nx, ny, isPunch]);
```

다음 탐색 결과가 1이지만 아직 벽을 부수지 않았다면 벽을 부순 결과에 이전 값의 1을 더한 값을 저장해준다. 그 뒤에 이제는 벽을 부순 결과로 큐에 넣는다.
```js
visited[nx][ny][1] = visited[x][y][0] + 1;
queue.enqueue([nx, ny, 1]);
```


요렇게 하고 풀릴 줄 알았지만 이번엔 메모리 초과였다... 요것은 최단 경로가 존재하는데 거리가 길다고 판명된 경로를 탐색하느라 발생한 오류였다.... 진짜 너무 어려워.,

다음 탐색 결과가 0일 때의 조건을 수정해줘야 했는데 다음 탐색 결과가 0임과 동시에, 더 짧은 경로로 갈 수 있는 지를 체크해서 경로가 큰 연산을 무시해줘야 한다는 것이다...
```js
if (matrix[nx][ny] === 0 && (visited[nx][ny][isPunch] === 0 || visited[nx][ny][isPunch] > nextDistance))
```


또한 벽을 만난 경우에도 선경써줘야한다...
```js
if (matrix[nx][ny] === 1 && isPunch === 0 && visited[nx][ny][1] === 0)
```

요렇게 수정하고 나니 성공...! 이 유형 익숙해지면 좋겠다.

## ⏰ 시간복잡도
O(N * M)일 듯 싶다.
