### PR TITLE
[250215] 쿠키 (벽 부수고 이동하기 2)

### DIFF
--- a/cookie/14442.js
+++ b/cookie/14442.js
@@ -1,0 +1,91 @@
+class Node {
+  constructor(value) {
+    this.cur = value;
+    this.next = null;
+  }
+}
+
+class Queue {
+  constructor() {
+    this.front = 0;
+    this.rear = 0;
+    this.length = 0;
+  }
+
+  size() {
+    return this.length;
+  }
+
+  push(element) {
+    const node = new Node(element);
+    if (this.length === 0) {
+      this.front = node;
+    } else {
+      this.rear.next = node;
+    }
+
+    this.rear = node;
+    this.length++;
+  }
+
+  pop() {
+    if (this.length === 0) return false;
+    const removeElement = this.front.cur;
+    this.front = this.front.next;
+    this.length--;
+    return removeElement;
+  }
+}
+
+const fs = require("fs");
+const [input, ...rest] = fs.readFileSync(0, "utf8").trim().split("\n");
+
+const [n, m, k] = input.split(" ").map(Number);
+const matrix = rest.map((row) => row.split("").map(Number));
+
+const distance = Array.from({ length: n }, () =>
+  Array.from({ length: m }, () => Array.from({ length: k + 1 }).fill(Infinity))
+);
+const directions = [
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+  [0, 1],
+];
+
+const bfs = (startX, startY) => {
+  const queue = new Queue();
+  distance[startX][startY][0] = 1;
+  queue.push([startX, startY, 0]);
+
+  while (queue.size()) {
+    const [x, y, breakCount] = queue.pop();
+
+    if (x === n - 1 && y === m - 1) {
+      return distance[x][y][breakCount];
+    }
+
+    const nextDistance = distance[x][y][breakCount] + 1;
+
+    for (const [dx, dy] of directions) {
+      const nx = x + dx;
+      const ny = y + dy;
+
+      if (nx >= 0 && nx < n && ny >= 0 && ny < m && distance[nx][ny][breakCount] === Infinity) {
+        // 0이고 이전보다 더 나은 결과가 있을 때
+        if (matrix[nx][ny] === 0 && distance[nx][ny][breakCount] > nextDistance) {
+          distance[nx][ny][breakCount] = nextDistance;
+          queue.push([nx, ny, breakCount]);
+          // 1이지만 아직 breakCount보다 넘치지 않았을 때
+        } else if (matrix[nx][ny] === 1 && breakCount < k && distance[nx][ny][breakCount + 1] > nextDistance) {
+          distance[nx][ny][breakCount + 1] = nextDistance;
+          queue.push([nx, ny, breakCount + 1]);
+        }
+      }
+    }
+  }
+
+  return -1;
+};
+
+console.log(bfs(0, 0));


### PR DESCRIPTION
## 🏷️ 백준번호
- [14442](https://www.acmicpc.net/problem/14442)

## ✏️ 풀이방법
어제 푼 문제의 연장선 문제.
어제 푼 문제는 벽을 한 번만 부실 수 있었지만 이번엔 K번까지 벽을 부술 수 있다. 그래서 distance 3차원 배열에서 마지막 벽 관련의 길이를 2가 아니라 K + 1로 잡아줘야 한다.

### 또 나타나는 시간 초과
어제 벽 부수기 문제를 풀며 Queue를 리스트가 아니라 직접 구현해서 사용했었다.
그러나 이마저도 충분하지 않았다. Queue 구현도 배열로 접근하지 않고 링크드리스트를 활용해야 했던 것;;;;
입력의 수가 매우 크기 때문에 이 연산 과정도 배열을 허용하지 않는 것 같다...

### distance의 초기값 Infinity로 설정
이전에는 방문하지 않은 distance배열의 초기값을 0으로 설정했었다. 그러니깐 if문을 설정하기가 매우 까다로웠다.
if문 내에서 이웃 노드의 다음 방문이 현재 노드의 다음 방문 시간보다 크면 이를 탐색하지 않는 조건을 세우며 0으로 설정하니 0인지 검사와 > 연산을 두 번 하니, 계산도 복잡하고 연산횟수가 많아서 시간 초과가 나는 것 같아서... 초기값을 Infinity로 바꿨다. 방문하지 않은 노드는 Infinity로 설정하면 > 연산 한 번으로 끝나기 때문에 연산 횟수를 줄일 수 있었다.. 다음에 기억해야지

나머지 과정은 이전 벽 부수고 이동하기 문제와 비슷했다.. Queue 구현 방식을 링크드리스트로 구현하는 것과 distance의 초기값 설정에 대한 관점을 얻어갈 수 있는 문제였다.


## ⏰ 시간복잡도
N * M 배열에서 벽을 부술 수 있는 경우의 수 K가 있으니 O(N*M*K)이다.
