### PR TITLE
[Day4] 올리

### DIFF
--- a/imxyjl/1260.js
+++ b/imxyjl/1260.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf8').trim().split('\n');
+
+const [n, m, v] = input[0].split(' ').map(Number);
+input.shift();
+
+const adj = Array.from({ length: n + 1 }, () => []);
+input.forEach(line =>{
+    const [v1, v2] = line.split(' ').map(Number);
+    adj[v1].push(v2);
+    adj[v2].push(v1)
+});
+
+adj.forEach(edges => edges.sort((a, b) => a - b));
+
+const bfsRes = [];
+const bfsVis = Array(n + 1).fill(0);
+const bfs = () =>{
+ 
+        const q = [v];
+        bfsRes.push(v);
+        bfsVis[v] = 1;
+
+        while(q.length){
+            const v1 = q.shift();
+            adj[v1].forEach(v2 => {
+                if(!bfsVis[v2]){
+                    
+                    q.push(v2);
+                    bfsVis[v2] = 1;
+                    bfsRes.push(v2);
+                }
+            })
+        }
+    
+}
+
+const dfsRes = [];
+const dfsVis = Array.from({length: n+1}).fill(0);
+
+const dfs = (curV) => {
+    dfsVis[curV] = 1;
+    dfsRes.push(curV);
+    
+    adj[curV].forEach(v2 =>{
+        if(!dfsVis[v2]) dfs(v2); 
+    });
+};
+
+bfs();
+dfs(v);
+
+console.log(dfsRes.join(' '));
+console.log(bfsRes.join(' '));


### PR DESCRIPTION
## 🏷️ 백준번호
- [1260](https://www.acmicpc.net/problem/1260)

## ✏️ 풀이방법
- 그래프 구조로 bfs와 dfs를 수행한다.
- 주의) dfs는 반복문으로도, 재귀로도 구현할 수 있으나 반복문으로 dfs 방문 순서를 출력하는 경우 일반적인 dfs 방문 순서와 다르게 나올 수 있다! (고 함)
  - 반복문을 사용하는 재귀는 인근 정점들에 실제로 방문하기 전에 방문 표시를 남기기 때문
  - 오리지널 dfs는 실제로 방문했을 때 방문 표시를 남긴다.  

### bfs
- 현재 방문한 정점의 인근 정점들 중 방문하지 않았던 것들을 큐에 넣고 방문한다.

### dfs
- 현재 재귀로 넘어온 정점은 무조건 방문
- 이후 현재 정점에 이어진 다른 정점들을 방문한 적 없다면 해당 정점으로 재귀를 돌린다.

## ⏰ 시간복잡도
모든 간선과 정점을 한 번 방문하므로 O(V + E)

## 기타
- 한 번 틀렸었는데 양방향 그래프인 걸 간과했음;;
- 2년 전에 그래프 구현하는 걸 배웠는데 그새 까먹어서 다시 공부함...