### PR TITLE
[Day6] 올리

### DIFF
--- a/imxyjl/2206.js
+++ b/imxyjl/2206.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf8').trim().split('\n');
+
+const [n, m] = input[0].split(' ').map(Number);
+input.shift();
+
+const dx = [1, 0, -1, 0];
+const dy = [0, 1, 0, -1];
+const bd = input.map(line => line.split('').map(Number));
+
+function create3DArray(x, y, z, initV = 0) {
+  return Array.from({ length: x }, () =>
+    Array.from({ length: y }, () =>
+      Array.from({ length: z }, () => initV)
+    )
+  );
+}
+
+class Q {
+    constructor(){
+        this.arr = {};
+        this.front = 0;
+        this.end = 0;
+    }
+
+    size(){
+        return this.end - this.front;
+    }
+
+
+    enq(v){
+        this.arr[this.end++] = v;
+    }
+
+    deq(){
+        const tmp = this.arr[this.front];
+        delete this.arr[this.front];
+        this.front++;
+        
+        if(this.front === this.end){
+            this.front = this.end = 0;
+        }
+        
+        return tmp;
+    } 
+}
+
+
+const bfs = (bx, by) => {
+    const dist = create3DArray(n, m, 2, -1);
+    const q = new Q();
+    q.enq([0,0,0]);
+
+    dist[0][0][0] = 0;
+
+    while(q.size() > 0){
+        const [curX, curY, isBroken] = q.deq();
+
+        if(curX === n-1 && curY === m-1) return dist[curX][curY][isBroken] + 1;
+
+        for(let dir=0; dir<4; dir++){       
+            const nx = curX + dx[dir];
+            const ny = curY + dy[dir];
+
+            if(nx <0 || nx >=n || ny <0 || ny >=m) continue;
+
+            if (bd[nx][ny] === 0 && dist[nx][ny][isBroken] === -1) {
+                dist[nx][ny][isBroken] = dist[curX][curY][isBroken] + 1;
+                q.enq([nx, ny, isBroken]);
+            } else if (bd[nx][ny] === 1 && isBroken === 0 && dist[nx][ny][1] === -1) {
+                dist[nx][ny][1] = dist[curX][curY][0] + 1;
+                q.enq([nx, ny, 1]);
+            }
+        }
+    }
+    return -1; 
+};
+
+console.log(bfs(0, 0));


### PR DESCRIPTION
## 🏷️ 백준번호
- [2206](https://www.acmicpc.net/problem/2206)

## ✏️ 풀이방법
- 시간 초과를 막기 위해 메모리를 사용해야 한다. 
- 벽을 부순 적이 있느냐를 판별해야 하는데, 지금까지 벽을 부순 적이 있었냐 + 지금 벽을 부수는 것이 최적이냐를 한 번의 BFS로 판별해야 한다. 
- 이동 케이스
  - 다음 탐색 대상이 0이고 방문한 적 없는 경우 -> 거리를 증가시키고 다음 탐색 대상으로 선정(큐에 넣음)
  - 다음 탐색 대상이 1인 경우
    - 다음 탐색 대상을 방문한 적 없어야 함 (BFS 기본조건)
    - 현재 탐색 중인 대상의 상태가 벽을 부순 적 없는 상태여야 함
    => 벽을 부수는 탐색을 진행. 값이 0이었을 때와 달리, 벽을 부쉈으므로 거리는 벽을 부순 상태의 거리를 갱신해야 함. 즉 z값이 1로 고정됨 
- 위 과정에서 `[n-1][m-1]`에 도달하면 그 거리를 리턴, 이 if문에 들어가지 못하고 반복문이 종료되면 끝까지 도달하지 못한 것이므로 -1을 리턴
  
## ⏰ 시간복잡도
- BFS를 한 번만 수행하므로 O(nm)
- 모든 좌표에 대한 BFS는 당연히... O(n²m²)

## 기타
- 처음엔 냅다 모든 칸에 대해 bfs 돌렸는데 1000 * 1000이라 역시 터짐^^ 
- 저 분기처리만으로 최적해를 구할 수 있을까 싶었는데, 원하는 좌표에 도달한 경우 바로 값을 리턴하고 끝에 도달한 경우는 탐색 실패로 생각해 -1을 리턴해준다고 생각하니까 이해가 됐다. 

- 항상 배열 생성을 `Array.from({length: len})` 방식으로 해주다가 Array.from(Array(len)) 방식으로 해봤는데 놀랍게도 메모리 초과가 난다. 전자를 사용해야 희소 배열을 지원해서 메모리를 아낀다고 함 
- js는 값 넣고 빼는 건 참 쉬운데 배열 세팅해주기가 까다롭다... 