### PR TITLE
[Day7] 올리 - 토마토

### DIFF
--- a/imxyjl/7576.js
+++ b/imxyjl/7576.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+
+const [n, m] = input[0].split(' ').map(Number);
+input.shift();
+
+const bd = input.map(str => str.split(' ').map(Number));
+const dist = Array.from({length: m}, () => Array(n).fill(0));
+const dx = [1, 0, -1, 0];
+const dy = [0, 1, 0, -1];
+
+class Q {
+    constructor(){
+        this.arr = {};
+        this.front = 0;
+        this.end = 0;
+    }
+    size(){
+        return this.end - this.front;
+    }
+    enq(v){
+        this.arr[this.end++] = v;
+    }
+
+    deq(){
+        const tmp = this.arr[this.front];
+        delete this.arr[this.front];
+        this.front++;
+
+        if(this.front === this.end) this.front = this.end = 0;
+      
+        return tmp;
+    }
+}
+
+const q = new Q();
+
+for(let i=0; i<m; i++){
+    for(let k=0; k<n; k++){
+        if(bd[i][k] === 1) q.enq([i,k]);
+        if(bd[i][k] === 0) dist[i][k] = -1;
+    }
+}
+
+while(q.size() > 0){
+    const [curX, curY] = q.deq(); //시간초과예상...
+
+    for(let dir=0; dir<4; dir++){
+        const nx = curX + dx[dir];
+        const ny = curY + dy[dir];
+
+        if(nx <0 || nx>=m || ny <0 || ny >=n) continue;
+        if(dist[nx][ny] >=0 || bd[nx][ny] === -1) continue; // 2번째 조건이 이미 1번째에 포함됨
+
+        bd[nx][ny] = 1; // dist 조건만으로 정확한 거리를 구할 수 있음. 1로 바꾸는 것도 불필요함
+        dist[nx][ny] = dist[curX][curY] + 1;
+        q.enq([nx, ny]);
+    }
+}
+
+const isPossible = () => {
+    let max = 0;
+    for(let i=0; i<m; i++){
+        for(let k=0; k<n; k++){
+            if(bd[i][k] === 0) return -1;
+            max = Math.max(max, dist[i][k]);
+        }
+    }
+   return max; 
+}
+
+console.log(isPossible());


### PR DESCRIPTION
## 🏷️ 백준번호
- [7576](https://www.acmicpc.net/problem/7576)
- 정말 **BFS의 동작 방식**을 잘 알고 있는지를 가볍게 테스트해볼 수 있는 문제였읍니다. 추천!
- 3차원 배열 버전 문제도 있음!

## ✏️ 풀이방법
- 핵심 키워드: BFS의 시작점이 여러 군데여도, 어디서 먼저 탐색하는지는 고려할 필요가 없다.
  - 너비 우선 탐색이므로 순서보다 몇 회차에 들어온 요소인지가 거리를 결정한다. 
  - 거리 값이 덮어씌워지는 것을 걱정할 필요 없다.
    - 일단 bfs 순회 여부를 결정할 때 이미 dist가 부여된 것은 탐색하지 않음
    - **이미 dist가 부여되어 있다 === 지금 탐색하는 것보다 짧은 거리로 탐색하는 방법이 있다**. 따라서 최단거리를 구해야 하는 현 상황에서는 별도의 처치가 필요하지 않음
- dist로 최단거리를 구했지만 모든 토마토가 익었을 때의 거리를 구해야 하므로 최단거리 중 가장 큰 값이 답이다. 

<br>

- 1인 칸(익은 토마토)이 퍼져나가야 하므로 처음에 1이었던 칸은 모두 큐에 넣고 시작
- 0인 칸은 bfs 탐색의 대상이므로 거리를 -1로 초기화
- => bfs가 가능한 조건은 dist가 -1인 경우만으로 한정 가능
- bfs 종료 후 통계: 거리 배열을 돌며 max값을 찾는다. 이때 dist가 -1인 칸을 발견하면 모든 토마토가 익지 않은 것이므로 -1을 리턴한다. 
  - dist만 따지는 게 제일 효율적인데, 나는 bfs 탐색할 때 bd를 1로 변경해줬던지라 dist 검사 대신 bd가 0인 것이 있는지를 검사했다. 

## ⏰ 시간복잡도
m * n에 대한 2차원 배열에 1회 BFS 수행하므로 O(nm)

## 기타
- 이 문제도 또 **n과 m**이 바뀌어 주어진다. (낚시 stop it)
  - 처음에 undefined나 0인 케이스들이 있어서 당황했는데 십중팔구는 역시 입력 잘못 받아서 생기는 문제...
  - 나는 n과 m을 일일이 바꿨는데 레퍼런스 코드 보니까 처음부터 n과 m의 입력을 바꿔 받아서 이후 코드에서는 익숙한대로 n이 가로, m이 세로로 보이게끔 했음!
- 이 문제도 큐를 직접 구현해야 했음. 백준에서 1000 * 1000짜리를 다루면 그냥 큐 구현해야 한다고 생각하면 될 듯 