### PR TITLE
[250219] 쿠키(균형 잡힌 줄서기)

### DIFF
--- a/cookie/1797.js
+++ b/cookie/1797.js
@@ -1,0 +1,32 @@
+const fs = require("fs");
+const [input, ...rest] = fs.readFileSync(0, "utf8").trim().split("\n");
+const n = parseInt(input, 10);
+
+const lineInfo = rest
+  .map((row) => {
+    const [gender, point] = row.split(" ").map(Number);
+    return { gender: gender === 0 ? -1 : gender, point };
+  })
+  .sort((a, b) => a.point - b.point);
+
+let answer = -Infinity;
+
+let map = new Map();
+let balance = 0;
+
+map.set(0, -1);
+
+for (let i = 0; i < lineInfo.length; i++) {
+  balance += lineInfo[i].gender;
+
+  if (map.has(balance)) {
+    const left = map.get(balance) + 1;
+    const right = i;
+
+    answer = Math.max(answer, lineInfo[right].point - lineInfo[left].point);
+  } else {
+    map.set(balance, i);
+  }
+}
+
+console.log(answer);


### PR DESCRIPTION
## 🏷️ 백준번호
- [1797](https://www.acmicpc.net/problem/1797)

## ✏️ 풀이방법

![KakaoTalk_20250219_192100016](https://github.com/user-attachments/assets/67f20622-78ed-4c1b-b742-a3f7fb3f717f)

1과 0이 반복되는 배열 속에서 1과 0의 수가 같은 부분 배열을 선택해서 값이 제일 큰 경우를 답으로 출력하는 문제이다.
위 사진은 파랑 = 0 빨강 = 1로 생각했을 때, 값을 정렬해서 x축으로 나열한 모습이다.
여기서 2와 5사이가 0과 1의 수가 같고 이 차이가 22 - 11 = 11으로 제일 큰 값이다.

처음 접근한 방식은 4~25의 수의 누적 합을 구해서 1과 0의 수가 같을 때 오른쪽 인덱스까지 더한 값에서 왼쪽 인덱스까지 더한 값을 빼주려고 했다. 그러나... 그러나.. 여기서 문제 1과 0이 같은 경우를 구하는 것에서 막혔었다.

그래서 다르게 접근한 방식이 해시 맵이다. 이번 문제를 풀면서 처음 사용해봤는데 딱 이런 경우에 사용하기 좋은 알고리즘이었다.

#### [1, 0, 1, 0, 1, 1, 1] 의 배열이 있을 때 1과 0의 수가 같아지는 인덱스를 구하는 방법

js의 Map 객체를 사용해서 위를 찾을 건데 Map의 키는 밸런스(현재 인덱스까지 합), 값은 인덱스이다.
참고로 이 알고리즘을 사용할 때 1, 0, 1, 0 패턴을 찾기 위해 1, 0 두 합이 0이 되도록 바꿔줘야한다.
즉  [1, 0, 1, 0, 1, 1, 1] ->  [1, -1, 1, -1, 1, 1, 1] 로 해주어야 한다는 의미이다. 그래야 다시 balance가 맞춰지는 순간이 와서 구간을 인식할 수 있기 때문

초기 밸런스 값으로 0을 저장하고 인덱스로 -1을 저장해둔다.
```js
map.set(0, -1);
```

그 후에 위 배열을 순회하며 balance 값을 더해나간다.
```js
let balance = 0;

for (let i = 0; i < list.length: i++) {
  balance += list[i];
}
```

반복문을 돌다가 Map에 저장된 밸런스 키가 있다면 (밸런스가 동일하다는 뜻은 1, 0의 수가 동일하다는 의미)
왼쪽은 Map에서 인덱스를 꺼내서 사용하며, 오른쪽은 i를 사용하면 된다.

다만 주의할 점은 왼쪽은 아래와 같이 1을 더해야한다는 점, 왜냐면 시작할 때 인덱스를 -1로 두고 시작했기 때문이다.
```js
map.get(balance) + 1
```

이렇게 1과 0이 같은 순간의 왼쪽과 오른쪽 인덱스를 가져왔다면, 인덱스로 값을 접근해서 차이를 저장하면 된다.
이 값의 최댓값을 저장하기 위해 Math.max를 사용해서 최댓값을 저장해서 출력하면 끝이다.


## ⏰ 시간복잡도
for문 한 번에 연산이 끝나므로 O(N)이다.
