### PR TITLE
[250220] 쿠키 (니가 싫어 싫어 너무 싫어 오지 마 내게 찝쩍대지마)

### DIFF
--- a/cookie/20440.js
+++ b/cookie/20440.js
@@ -1,0 +1,40 @@
+const fs = require("fs");
+const [input, ...rest] = fs.readFileSync(0, "utf8").trim().split("\n");
+
+const n = parseInt(input, 10);
+const mosquitoes = rest.map((time) => time.split(" ").map(Number));
+
+const timeTableMap = new Map();
+
+for (let i = 0; i < n; i++) {
+  const [start, end] = mosquitoes[i];
+
+  timeTableMap.set(start, (timeTableMap.get(start) || 0) + 1);
+  timeTableMap.set(end, (timeTableMap.get(end) || 0) - 1);
+}
+
+const timeTable = [...timeTableMap].sort((a, b) => a[0] - b[0]);
+
+let sum = 0;
+let max = 0;
+let answerStart = 0;
+let answerEnd = 0;
+
+let opened = false;
+
+timeTable.forEach((timeInfo) => {
+  const [time, mosquitoes] = timeInfo;
+  sum += mosquitoes;
+
+  if (sum > max) {
+    max = sum;
+    answerStart = time;
+    opened = true;
+  } else if (sum < max && opened) {
+    answerEnd = time;
+    opened = false;
+  }
+});
+
+console.log(max);
+console.log(`${answerStart} ${answerEnd}`);


### PR DESCRIPTION
## 🏷️ 백준번호
- [20440](https://www.acmicpc.net/problem/20440)

## ✏️ 풀이방법
방의 모기가 제일 많은 시간대의 모기 마리 수와 시작과 끝 시간을 구하는 문제이다.
처음 접근 방식으로 배열을 선언하고 시작과 끝 시간 사이를 1씩 더하며 문제를 해결하려고 했다.
하지만 시작, 끝 시간으로 21억까지 들어올 수 있다. 위 방식대로 풀면 무조건 시간 초과가 날 수 밖에 없다.

그래서 다음 접근으로 좌표 압축 방식을 사용했다.
수평선을 그은 뒤에 모기가 들어올 때는 +1, 나갈 때는 -1을 찍는 방식으로 진행해야 한다.
이 때 들어온 경우와 나간 경우가 같은 경우 0으로 지워줘야 하는데,, 여기서 삽질도 많이 하고, 시간 내에 도출한 답도 반례가 있어서 완전하지 못 했다....  

![image](https://github.com/user-attachments/assets/493dd0c6-60e8-4fcb-a3e0-ca683de85716)

해결책은 이전 값을 가져와서 값이 없다면 0, 있다면 그 값에서 +1, -1을 해줘야 했던 것이다.
```js
timeTableMap.set(start, (timeTableMap.get(start) || 0) + 1);
timeTableMap.set(end, (timeTableMap.get(end) || 0) - 1);
```

그리고 그 다음은 단순하게 접근했으면 풀렸을 것 같은데, 복잡하게 생각하느라 풀지 못했다.
현재까지 합산과, 최대 모기 수, 그리고 답 시작 지점과, 답 끝 점을 세우고, boolean으로 가드를 세운다.

그 뒤 반복문을 돌며, sum에 +1, -1 정보를 합산해서 sum이 max보다 크다면 그 때의 sum을 max로 저장하고 시작점을 기록한다. 그리고 다음 합산으로 sum이 max보다 작아지는 순간이 오면 그 때 끝 점을 기록하는 것이다.

하아... 이렇게 간단한데,,, 왜 삽질을 했을까........
누적 합이라는 패턴에 익숙하지 않아서 그런 것 같기도 하고, 아니면 미리 누적해서 더해놓는 것에만 집중해서 문제의 본질을 접근하지 못 했던 것 같다.... 진짜 돌아보니 아쉬운 문제네;;;;

## ⏰ 시간복잡도
for문으로 N만큼 반복하는 것이 병렬적으로 실행되므로 O(N)이다.

