### PR TITLE
[Day9] 올리 - 구간 합 구하기 4

### DIFF
--- a/imxyjl/11659 구간 합 구하기 4.js
+++ b/imxyjl/11659 구간 합 구하기 4.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+
+const [n, m] = input[0].split(' ').map(Number);
+const arr = [0, ...input[1].split(' ').map(Number)];
+
+let line = 2;
+const testCase = [];
+for(line; line<input.length; line++){
+    const [i, j] = input[line].split(' ').map(Number);
+    testCase.push([i,j]);
+}
+
+const dp = Array.from({length:n+1}).fill(0);
+
+dp[1] = arr[1];
+
+for(let k=2; k<=n; k++){
+    dp[k] = dp[k-1] + arr[k];
+}
+
+for(let t=0; t<m; t++){
+    const [i, j] = testCase[t];
+    console.log(dp[j] - dp[i-1]);
+}


### PR DESCRIPTION
## 🏷️ 백준번호
- [11659](https://www.acmicpc.net/problem/11659)

## ✏️ 풀이방법
- 공간을 써서 시간을 줄이는 전형적인 dp...인가?
- 1차원 배열에서는 단순히 값을 더해나가면 됨

- 근데 여기까지만 생각하고 2차원 배열을 돌리니까 메모리 초과가 남
- 한번 더 머리를 써서, 주어진 구간의 합은 전체 합에서 앞 구간 - 1까지의 합을 뺀 것이라는 것까지 도출해야 for문을 한 번만 쓰고 풀 수 있다. 
- 1-indexed로 푸는 게 깔끔함! (0으로 풀면 -1 인덱스에 접근하는 예외 처리 필요)

## ⏰ 시간복잡도
1차원 배열을 순회하므로 O(n)

## 기타
- 이거 말고 하나 더 풀고 싶었는데 할 일이 많아 미뤄졌다...
- 로그인에서 해방되고파...🫠