### PR TITLE
[Day11] 올리 (모기어쩌고)

### DIFF
--- a/imxyjl/20440 모기어쩌고.js
+++ b/imxyjl/20440 모기어쩌고.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+
+const n = Number(input[0]);
+
+const t = [];
+let line = 1;
+for(line; line<input.length; line++){
+    const [s, e] = input[line].split(' ').map(Number);
+    t.push([s,e]);
+}
+
+const ps = [];
+t.forEach(([s, e]) => {
+    ps.push([s, 1]);
+    ps.push([e, -1]);
+});
+
+ps.sort((a,b) => a[0] - b[0]);
+
+let maxStart, maxEnd = 0;
+let curCnt = 0, maxCnt = 0, curIdx = 0;
+while(curIdx < ps.length){
+    const curPos = ps[curIdx][0];
+
+    // 중복된 좌표값이 남아있는 경우를 처리 -> 앞서 정렬했기 때문에 가능!
+    while(curIdx < ps.length && ps[curIdx][0] === curPos){
+        curCnt += ps[curIdx][1];
+        curIdx++;
+    }
+
+    // 조사한 수에 대한 처리
+    if(curCnt < maxCnt){
+        if(maxEnd ===0) maxEnd = ps[curIdx-1][0]; // curIdx 하면 안됨. 이미 줄어든 상태이기 때문
+    } 
+    if(curCnt > maxCnt){
+        maxCnt = curCnt;
+        maxStart = curPos;
+        maxEnd = 0; // 왜? -> 새로운 끝을 지정해주기 위해서
+        // 문제에서 언젠가 퇴장 시간이 꼭 주어지므로 end가 0인 채로 끝나는 케이스는 없다!
+    }
+}
+
+console.log(maxCnt);
+console.log(maxStart, maxEnd);


### PR DESCRIPTION
## 🏷️ 백준번호
- [20440](https://www.acmicpc.net/problem/20440)
- 합을 구하는 것 자체는 엄청 어렵지는 않다고 생각(물론 골3이라는 난이도에 비해!)
- 하지만 골3인 데는 이유가 다 있었다. 구현이 까다로움


## ✏️ 풀이방법
### 도입
- 풀이가 크게 2가지로 나뉘는 것 같았다.
  - **map 사용하기**: key로 현재 좌표값을 저장해서 필요할 때마다 꺼내 쓰고 갱신
  -  **그냥 vector(배열) 사용하기**: 단순 기록만 남긴 뒤 나중에 취합
- 이상하게도 처음 풀 때 map은 전혀 떠오르지 않았지만, unique한 좌표값을 저장하고 계속 접근해야 한다는 점에서 떠올렸으면 좋았을 것 같다.
- 그런데 map을 쓰면 배열 메서드를 바로 쓸 수도 없고, 이래저래 코드가 조금 복잡해져서 왠지 내키지 않았다. 
- map 썼을 때의 문제?
  - map을 쓰면 정렬 부분이 귀찮아짐   

- 이에 더해 `좌표 압축`이라는 것을 하는 사람도 있고, 하지 않는 사람도 있었는데... 이것을 쓰지 않아도 해결할 수 있었다.
  - 내가 최종 참고한 답안에서는 좌표 압축을 사용하지 않았는데, 대신 사용한 방법이 다른 문제에서 사용하기 좋을 테크닉인 것  같아 사용하지 않았다.

- 별개로 `좌표 압축`은 ps할 때 응용이 되는 알고리즘 유형이 아니라 그를 위한 유틸리티 개념으로 가져가는 것 같아서 공부해볼 예정이다. (언어별로 국룰 조합도 있는듯..?) 

### 모기 조사하기
- 주어진 입력을 돌면서 **모기가 들어온 구간에서는 1을 저장하고, 나가는 구간에서는 -1을 저장**한다.
  - 중간 구간은 어떻게 해야 하나 싶었는데, 가능한 체류 시간이 최대 21억이라 중간을 전부 탐색하면 100% 시간초과 예상함.무조건 두 좌표만으로 계산을 끝내야겠다는 생각이 들었다. 
- 이러면 당연히 같은 좌표가 중복돼서 들어가고, 오름차순 정렬도 깨져서 합을 조사할 때 시간초과가 날 수도 있다.
- 그렇다면? **정렬**하면 된다~~~
  - 근데 정렬할 수 있을까? [찾아 본 결과](https://invrtd-h.tistory.com/50) **입력이 100만개일 때 nlogn정도는 버틴다고 함. 천만일 때는 O(n)**
- 정렬했으니 이제 배열을 순차적으로 돌면서 최댓값과 그 구간을 찾으면 된다.

### 시작과 끝 마킹하기
- 이중 while문으로 탐색 범위 조정하기
- 최댓값이 시작되는 구간, 끝나는 구간을 정확히 마킹하기

이 문제가 골3이 된 이유는 이 부분 때문인 것 같다.
위 동작을 위해 let 변수가 5개나 필요하다. 먼저 최댓값 구간의 시작과 끝 좌표, 최댓값이 있다.
그리고 모기 카운팅을 위한 임시변수 curCnt와 이중 while문을 O(n)으로 탐색하기 위한 curIdx까지 필요하다.

```js
while(curIdx < ps.length){
    const curPos = ps[curIdx][0];

    // 중복된 좌표값이 남아있는 경우를 처리 -> 앞서 정렬했기 때문에 가능!
    while(curIdx < ps.length && ps[curIdx][0] === curPos){
        curCnt += ps[curIdx][1];
        curIdx++;
    }
    ...
``` 
외부 while문은 기본 탐색을 위한 조건이다. curPos는 이 값에 접근할 일이 두 번 있어서 가독성을 위해 별도로 분리함
내부 while문에서 진짜 탐색을 한다. **curIdx++를 했을 때 배열 길이를 초과**할 수 있으니 length 검사를 중복으로 걸어준다. 두 번째 조건이 누적합을 구하기 위한 조건이다. **현재 탐색 중인 좌표의 끝이 보일 때까지 탐색**한다.

다음은 모기 카운팅한 결과를 처리해주는 코드이다.
```js
// 조사한 수에 대한 처리
    if(curCnt < maxCnt){
        if(maxEnd ===0) maxEnd = ps[curIdx-1][0]; // curIdx 하면 안됨. 이미 줄어든 상태이기 때문
    } 
    if(curCnt > maxCnt){
        maxCnt = curCnt;
        maxStart = curPos;
        maxEnd = 0; // 왜? -> 새로운 끝을 지정해주기 위해서
        // 문제에서 언젠가 퇴장 시간이 꼭 주어지므로 end가 0인 채로 끝나는 케이스는 없다!
    }
```
`maxEnd`처리가 까다로웠다. 새 max를 설정할 때 maxEnd를 0으로 설정해줘야 한다. 새 최댓값 구간이 시작되니까 초기화를 해 주는 느낌이다.

그런데 여기서 들었던 의문은 그럼 maxEnd가 0인 채 끝나버리는 경우가 없나? 였다. 하지만 **모기는 언젠가 꼭 나가기 때문에**, 맨 마지막 좌표에서라도 모기 수가 줄어들게 되고, 그때 maxEnd  세팅이 일어나므로 그런 일은 없다. 

다음은 현재 조사한 모기 수가 최댓값보다 작을 때이다.
여기서 `curIdx-1`값에 접근하는 이유가 헷갈렸는데 답이 의외로 간단했다. while문에서 curIdx를 무조건 증가시키고 나오기 때문에 curIdx에 그대로 접근하면 이미 모기 수가 줄어든 점을 마킹하는 셈이 된다. (구현능력 이슈..^^)

또 `maxEnd ===0`일 때만 갱신하는 것도 의아했다. 
이건 막 **maxStart 갱신이 이루어졌을 때, 그 직후에만 maxEnd를 세팅해서 최댓값 구간을 정확히 기록**하기 위해서였다. 이게 없으면, 현재 max값보다 작은 구간이 나올 때마다 end 좌표를 갱신하게 돼서 오답이 나온다.

이렇게 모기 분석 완료😅

## ⏰ 시간복잡도
- 조사할 때 1차원 배열을 한 번 순회하므로 O(n)
- 조사를 마치고 합을 내기 전에 정렬을 수행하므로 O(nlogn)
- 최종 합을 낼 때 역시 O(n)
해서 총 `O(nlogn)`


## 기타
[참고한 블로그](https://unfunhy.tistory.com/110)