### PR TITLE
[250224] 쿠키(구간 합 구하기 5)

### DIFF
--- a/cookie/11660.js
+++ b/cookie/11660.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const [input, ...rest] = fs.readFileSync(0, "utf8").trim().split("\n");
+
+const [n, m] = input.split(" ").map(Number);
+
+const matrix = rest.slice(0, n).map((row) => row.split(" ").map(Number));
+const points = rest.slice(n, n + m).map((row) => row.split(" ").map(Number));
+
+const prefixSum = Array.from({ length: n + 1 }, () => Array.from({ length: n + 1 }).fill(0));
+
+for (let i = 1; i <= n; i++) {
+  for (let j = 1; j <= n; j++) {
+    prefixSum[i][j] = prefixSum[i - 1][j] + prefixSum[i][j - 1] + matrix[i - 1][j - 1] - prefixSum[i - 1][j - 1];
+  }
+}
+
+points.forEach((point) => {
+  const [x1, y1, x2, y2] = point;
+  const rangeSum = prefixSum[x2][y2] - prefixSum[x1 - 1][y2] - prefixSum[x2][y1 - 1] + prefixSum[x1 - 1][y1 - 1];
+  console.log(rangeSum);
+});


### PR DESCRIPTION
## 🏷️ 백준번호
- [11660](https://www.acmicpc.net/problem/11660)

## ✏️ 풀이방법
전형적인 누적합 문제이다. 다만 2차원 배열이라 조금 헷갈릴 부분이 있지만..

1,2,3,4,5
6,7,8,9,1
2,3,4,5,6

에서 (2,2) - (3,4) 사이의 합을 구하려고 하면  8+9+1+4+5+6을 해주면 된다.
다만 주어지는 구간이 1개가 아니라 여러 개이고, 구간마다 반복문을 사용해서 푼다면, O(N^3)이 되어 시간초과가 날 것이다.
그래서 해법은 위 행렬을 가지고 미리 누적합을 구해둔 뒤에 구간이 오면 누적합 정보를 이용하여 O(1)로 해결하면 된다.

#### 누적합을 구하는 과정
![image](https://github.com/user-attachments/assets/2ccdbfea-442c-4747-9209-04a4cfe31090)

위 사진을 보면 특정 point까지의 누적합은 (x좌표 - 1까지의 누적합) + (y좌표 - 1까지의 누적합) + (x좌표 -1, y좌표 - 1까지의 누적합) + point의 값을 해주면 구할 수 있다.

#### 누적합을 사용해서 구간 별 합을 구하는 과정
![image](https://github.com/user-attachments/assets/592cf7d1-9d35-4822-8066-0109c3ddf8b8)

(x, y까지의 누적합) - (x좌표 i -1, y까지의 누적합) - (x좌표, j-1까지의 누적합) + (i-1, j-1까지의 누적합)을 해주면 원하는 구간의 누적합을 구할 수 있다.

## ⏰ 시간복잡도
누적합을 구하는 과정 O(N^2) 답을 구하는 과정 O(N * 1) => 즉 O(N^2)이다.
