### PR TITLE
[Day12] 올리(최단거리)

### DIFF
--- a/imxyjl/1753 최단거리.js
+++ b/imxyjl/1753 최단거리.js
@@ -1,0 +1,108 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+
+// 정점, 간선의 개수
+const [v, e] = input[0].split(' ').map(Number);
+const sv = Number(input[1]);
+
+// 정점과 인접한 정점들을 기록하는 배열
+const adj = Array.from({ length: v+1 }, () => []);
+// 최단거리(최소가중치)를 저장하는 배열
+const d = Array.from({length: v+1}, () => Infinity);
+
+for(let i=2; i<input.length; i++){
+    // u에서 v로 가는 가중치 w인 간선
+    const [u, v, w] = input[i].split(' ').map(Number);
+    adj[u].push([w,v]);
+}
+
+class MinHeap {
+    constructor() {
+        this.h = [];
+    }
+    size() {
+        return this.h.length;
+    }
+    swap(idx1, idx2) {
+        [this.h[idx1], this.h[idx2]] = [this.h[idx2], this.h[idx1]];
+    }
+    add(v) {
+        this.h.push(v);
+        this.bubbleU(); 
+    }
+    remove() {
+        if (this.h.length === 0) return null;
+        if (this.h.length === 1) return this.h.pop();
+
+        const toRemove = this.h[0];
+        this.h[0] = this.h.pop();
+        this.bubbleD(); 
+        return toRemove;
+    }
+
+    bubbleU() {
+        let idx = this.h.length - 1;
+        let pIdx = Math.floor((idx - 1) / 2);
+
+        while (
+            this.h[pIdx] &&
+            this.h[idx][0] < this.h[pIdx][0]
+        ) {
+            this.swap(idx, pIdx);
+            idx = pIdx;
+            pIdx = Math.floor((idx - 1) / 2);
+        }
+    }
+
+    bubbleD() {
+        let idx = 0;
+        let leftIdx = idx * 2 + 1;
+        let rightIdx = idx * 2 + 2;
+
+        while (
+            (this.h[leftIdx] && this.h[leftIdx][0] < this.h[idx][0]) ||
+            (this.h[rightIdx] && this.h[rightIdx][0] < this.h[idx][0])
+        ) {
+            let smallerIdx = leftIdx;
+            if (
+                this.h[rightIdx]  &&
+                this.h[rightIdx][0] < this.h[smallerIdx][0]
+            ) {
+                smallerIdx = rightIdx;
+            }
+
+            this.swap(idx, smallerIdx);
+            idx = smallerIdx;
+            leftIdx = idx * 2 + 1;
+            rightIdx = idx * 2 + 2;
+        }
+    }
+}
+
+const pq = new MinHeap();
+d[sv] = 0;
+// 우선순위 큐에 0(가중치), 시작점 추가
+pq.add([d[sv], sv]); 
+
+while(pq.size() >0){
+    const [curW, curV] = pq.remove();
+    // 현재 가중치 최소값이 최단거리 테이블의 값과 같은가?
+    // 다르다면 예전에 넣어둔 최소 가중치가 더 작은 값으로 갱신되었다는 의미이므로 pass
+    if(d[curV] !== curW) continue;
+
+    // 현재 정점에서 이용 가능한 간선들을 조사
+    adj[curV].forEach((next) =>{
+        const [nextW, nextV] = next;
+        // 기존에 저장된 가중치보다 현재 탐색 가중치가 크면 pass
+        const tmpW = d[curV] + nextW;
+       if(d[nextV] <= tmpW) return; 
+        
+        d[nextV] = tmpW;
+        pq.add([d[nextV], nextV]);
+    });
+}
+
+for(let i=1; i<=v; i++){
+    if(d[i] === Infinity) console.log("INF");
+    else console.log(d[i]);
+}


### PR DESCRIPTION
## 🏷️ 백준번호
- [1753](https://www.acmicpc.net/problem/1753)
- 기본적인 다익스트라를 구현하는 문제

## ✏️ 풀이방법
### 최소 힙
- 먼저 최소 힙을 구현해야 함. (역시세상에서가장완벽한언어js)
- 주의할 점들
  - 리턴해야 하는 값들을 빠짐없이 리턴했는지 확인(특히 if문들에서)
  - 부등호 제대로 기입했는지 확인
  - 인덱스를 잡기 위한 부등호 비교 연산에서 제대로 된 값을 줬는지 확인. 우선순위를 따로 저장하는 경우 그것끼리 저장해야 함. 누락해도 에러 안나니까 조심!!
  - 단순히 값 자체로 우선순위를 준다면(일반 max, min힙) 그냥 1차원 배열로 구현, 특수한 우선순위 값이 필요하다면(당장 다익스트라 구현에 필요) 2차원 배열로 구현한다. 
    - 이 풀이에서는 `[priority, v]`로 주었다. 

### 다익스트라 알고리즘이란
유향/무향 그래프이고 간선의 **가중치가 음수가 아닌 그래프**에서,
**한 정점으로부터 다른 모든 정점까지의 최단거리**를 구할 수 있는 알고리즘

### 다익스트라 구현 방식
- 정석 방식(가중치가 확정됐음을 따로 관리) 대신 효율적인 방법(우선순위 큐 사용)으로 구현했다. 
- 먼저 다익스트라의 **시작점을 우선순위 큐에** 넣는다.
- 그리고 큐가 빌 때까지 아래 동작을 반복한다.
  - 큐에서 빼낸 요소의 **가중치가 그 요소의 현재 최단거리로 기록된 값과 같을 때만** 추가 탐색을 진행한다.
    - 아래 탐색 과정에서 현재 단계에서의 최단거리를 갱신하는데, 이 값은 항상 최신화되면서 더 작아지므로 두 값이 다르다 === 더 작은 값으로 나중에 갱신이 이루어졌다를 의미하기 때문이다. 즉 최신 최단거리가 아니므로 해당 정점에 대한 탐색을 하지 않는 것이다. 
  - (같은 경우) 현재 탐색 중인 정점에서 접근할 수 있는 간선들을 조사한다. 지금까지의 거리 + 다음 정점까지의 가중치를 계산하고, **기존에 기록되어있던 값보다 작으면 새로 갱신**하고, 아니면 그냥 넘어간다. **갱신한 경우 그 정점과 간선 정보를 큐에** 새로 넣는다. 

### 실제 구현
- 은 코드에 나와 있다. 
- 다만 기록하고 싶은 것들만 적음...

- 필요한 공간
  - **adj 정보(인접 리스트)**
    - `adj[u].push([w,v])`: 인덱스는 정점의 번호, 그리고 그 인덱스 배열에 인접한 정점의 번호와 가중치를 push
    - 보통 정점이 1부터 시작하기 때문에 0번 인덱스는 비워 놓고 **v+1**크기만큼 선언
    - `Infinity`로 초기화하면 된다. 
  - **최단거리 정보(1차원 배열)**: 인덱스는 정점의 번호, 그곳에 가중치 정보 하나만 저장

- 큐에 넣고 탐색할 때 변수가 꽤 많이 쓰인다. 헷갈리지 않기 위해서는 구조분해할당 필수!
  - 현재 기준이 되는 정점을 cur, 현재 정점에서 도달할 수 있는 정점들을 next, 새로 계산해준 가중치를 tmp로 지었다. tmp를 new라고 지었었는데 next랑 비슷하게 생겨서 막판에 실수함;; 변수 이름은 최대한 철자가 많이 다른 것들로 지어야 할 것 같다. 
  
## ⏰ 시간복잡도
- 존재하는 모든 간선이 우선순위 큐에 들어간다고 가정하면 O(eloge)
- 최단거리를 찾기 위해서 우선순위 큐에 삽입, 삭제를 진행하는데 각 연산마다 logn이 소모됨
- 위 연산을 모든 간선 e에 대해 수행하므로 eloge

## 기타
- 자료구조 실습때의 기억이 새록새록...
- [구현 참고한 블로그](https://blog.encrypted.gg/1037)
