### PR TITLE
[Day14] 올리(최소비용 구하기 2)

### DIFF
--- a/imxyjl/11779 최소비용 구하기 2.js
+++ b/imxyjl/11779 최소비용 구하기 2.js
@@ -1,0 +1,110 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+
+class PQ{
+    constructor() {
+        this.h = [];
+    }
+    size() {
+        return this.h.length;
+    }
+    swap(idx1, idx2) {
+        [this.h[idx1], this.h[idx2]] = [this.h[idx2], this.h[idx1]];
+    }
+    add(v) {
+        this.h.push(v);
+        this.bubbleU(); 
+    }
+    remove() {
+        if (this.h.length === 0) return null;
+        if (this.h.length === 1) return this.h.pop();
+
+        const toRemove = this.h[0];
+        this.h[0] = this.h.pop();
+        this.bubbleD(); 
+        return toRemove;
+    }
+
+    bubbleU() {
+        let idx = this.h.length - 1;
+        let pIdx = Math.floor((idx - 1) / 2);
+
+        while (
+            this.h[pIdx] &&
+            this.h[idx][0] < this.h[pIdx][0]
+        ) {
+            this.swap(idx, pIdx);
+            idx = pIdx;
+            pIdx = Math.floor((idx - 1) / 2);
+        }
+    }
+
+    bubbleD() {
+        let idx = 0;
+        let leftIdx = idx * 2 + 1;
+        let rightIdx = idx * 2 + 2;
+
+        while (
+            (this.h[leftIdx] && this.h[leftIdx][0] < this.h[idx][0]) ||
+            (this.h[rightIdx] && this.h[rightIdx][0] < this.h[idx][0])
+        ) {
+            let smallerIdx = leftIdx;
+            if (
+                this.h[rightIdx]  &&
+                this.h[rightIdx][0] < this.h[smallerIdx][0]
+            ) {
+                smallerIdx = rightIdx;
+            }
+
+            this.swap(idx, smallerIdx);
+            idx = smallerIdx;
+            leftIdx = idx * 2 + 1;
+            rightIdx = idx * 2 + 2;
+        }
+    }
+}
+
+const pq = new PQ();
+const v = Number(input[0]);
+const e = Number(input[1]);
+const adj = Array.from({length: v+1}, () => []);
+const d = Array.from({length: v+1}, () => Infinity);
+const pre = Array.from({length: v+1}, () => 0);
+
+for(let i=2; i<input.length - 1; i++){
+    // 출발 도시 번호, 도착지 번호, 비용 
+    const [u, v, w] = input[i].split(' ').map(Number);
+    adj[u].push([w,v]);
+}
+
+const [sv, ev] = input[input.length-1].split(' ').map(Number);
+d[sv] = 0;
+pq.add([d[sv], sv]);
+
+
+while(pq.size() >0){
+    const [curW, curV] = pq.remove();
+    if(d[curV] !== curW) continue;
+
+    adj[curV].forEach((next) =>{
+        const [nextW, nextV] = next;
+        const tmpW = nextW + d[curV];
+        if(tmpW > d[nextV]) return;
+
+        d[nextV] = tmpW ;
+        pre[nextV] = curV;
+        pq.add([d[nextV], nextV]);
+    })
+}
+
+const res = [];
+let curV = ev;
+while(curV !== sv){
+    res.push(curV);
+    curV = pre[curV];
+}
+res.push(curV);
+
+console.log(d[ev]);
+console.log(res.length);
+console.log(res.reverse().join(' '));


### PR DESCRIPTION
## 🏷️ 백준번호
- [11779](https://www.acmicpc.net/problem/11779)

## ✏️ 풀이방법
- 단순 다익스트라
- 지만 이번에는 경로 복원도 필요함.
  - 어떤 정점 v에 도달하기 이전의 정점을 저장하는 배열을 추가로 선언해서 사용한다. 
  - 최단거리일 때의 경로를 기록해야 하므로, 최단거리를 갱신할 때 같이 갱신해준다. 

## ⏰ 시간복잡도
- 다익스트라 국룰 O((N + E) log N)

## 기타
- **답은 같게 나오지만 시간복잡도나 메모리 효율 면에서 부족한 코드가 나올 수 있다**는 다익스트라의 악명(?)을 확인할 수 있는 문제였다. 
  - 코멘트에 달아두었는데, 가중치가 같은 경우에도 값들을 갱신해버리면 불필요한 탐색이 일어나 복잡도가 증가하게 된다. 
- 그리고 기본 예제랑 출력값이 달라서 디버깅을 2시간 넘게 했다. 
  -  **가능한 경로 중 아무거나 하나를 출력한다**는 문구를 보긴 했는데, 기본 예제가 바로 이 케이스였던 것이다;;;;;;;;;;;;;;;;;;;;;;; 대 빡 침
  - 고수의 말을 인용하자면 답이 하나라는 얘기가 없었으니 저 문구가 없었어도 알아차려야 한다고.........ps 쉽지않네.....
  - 그런데 저 말 자체는 납득이 간다. 다만 정작 저 문구를 읽었음에도 테케 돌려보고 다른 답이 나오니까 순간 '내가 틀렸나보다'로 넘어가버려서 문제...
- 바보이슈와 별개로 다른 언어에서는 가져다 쓰면 끝인 걸 추가로 디버깅하고 있으니 열받긴함... 그치만 이게 아직 pq에 덜 익숙해서 더 자주 생기는 문제인 것 같기도 해서 일단은 js하기로