### PR TITLE
[Day15] 올리(트리)

### DIFF
--- a/imxyjl/1068 트리.js
+++ b/imxyjl/1068 트리.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+const n = Number(input[0]);
+const treeInfo = input[1].split(' ').map(Number);
+const toRemove = Number(input[2]);
+
+const tree = Array.from({ length: n }, () => []);
+
+let root = 0;
+let leafCnt = 0;
+
+for (let i = 0; i < n; i++) {
+    if (treeInfo[i] === -1) root = i;
+    else tree[treeInfo[i]].push(i); 
+}
+
+const dfs = (curNode) => {
+    if (curNode === toRemove) return -1; // 삭제 노드 처리
+    if (tree[curNode].length === 0) { // 리프 노드일 경우
+        leafCnt++;
+        return 0;
+    }
+
+    // 탐색할 자식이 있는 경우 
+    tree[curNode].forEach(child => {
+        const dfsRes = dfs(child);
+        // 자식이 하나 있었는데 그 자식이 삭제된 노드인 경우 해당 노드도 leaf
+        if (dfsRes === -1 && tree[curNode].length === 1){
+            leafCnt++
+        }
+    });
+};
+
+if (root !== toRemove) dfs(root);
+console.log(leafCnt);


### PR DESCRIPTION
## 🏷️ 백준번호
- [1068](https://www.acmicpc.net/problem/1068)

## ✏️ 풀이방법
(언제나 그렇듯이) 문제를 잘 읽어야 한다.
- 이진 트리라는 보장이 없다. -> 인덱스 신공 불가능
- 인덱스를 쓰지 못하니까 정직하게 재귀를 통해 바닥까지 내려갔다가 올라와야 함
  - 마침 n도 50까지라 dfs 돌려도 시간 넉넉함 
- 루트 노드가 항상 0번째로 들어오는 노드라는 보장이 없다.

근데 나의 문제점: 인지는 했지만 재귀를 어떻게 짜면 좋을지 막막해서 못풀었음(ㅋㅋ
트리 생성 -> 특정 노드 삭제 -> 결과 탐색 순으로 재귀 구현하려고 하니까 까다로웠다. 
저럴 필요 없이 그냥 탐색하면서 삭제한 노드를 발견하면 값으로 분기처리하면 됐다. 

재귀 배울 때 어떻게 배웠냐...기억 회상

### 재귀 로직 짜기
- **종료 조건** 먼저 생각하기 -> 여기서 **리턴**이 이루어짐
  - 바닥에 도달한 경우: 당연히 여기서 return 안하면 무한루프
  - 더 이상 탐색을 지속할 필요가 없는 경우: 위와 비슷하지만, 특정 조건이 걸려 있는 경우가 많은 듯
  - 덧) 리턴값을 달리해서 1과 2를 하단에서 분기처리할 수 있다. 
- **매개변수** 무엇으로 할 것인가? -> 실시간으로 파고들어가는 재료

- 일반 로직 생각하기: 종료 조건에 해당하지 않는 경우에 수행하는 동작.
  - 이곳에서 재귀적으로 자신을 호출하게 된다. 

### 이 문제에서의 재귀
- 종료 조건
  -  **본인이 삭제 대상인 노드라면 바로 종료**: 처음에 이 방식을 생각 못함
  - 자식이 0개라면 leaf임 개수를 늘리고 종료(일반적인 종료)
  - 자식이 있다면 자식을 타고 내려가야 하므로 재귀적으로 진행
- 일반 로직: 자식을 탐색한다.
  - 자신의 자식들에 대해 모두 dfs를 호출한다.   
    - 이때 분기처리 들어감!
      - 순수하게 자식이 없었던 경우는 위의 종료 조건에서 처리하고 있다. 
      - 하지만, 내 자식이 삭제 대상인 노드였고, 그 자식이 유일했다면 나 또한 leaf가 된다. 
- 매개변수: 각 노드에 대한 검증이므로 노드 변수를 넘겨줘야 함

## ⏰ 시간복잡도
O(n)

인데 조금 헷갈려서 정리
- dfs이므로 모든 노드와 간선을 한 번씩 방문: O(v+e)
- 트리 노드가 n개일 때 간선은 n-1개 -> O(n + n - 1) => 결국 O(n)

## 기타
졸리다...
