### PR TITLE
[Day16] 올리(컵라면)

### DIFF
--- a/imxyjl/1781 컵라면.js
+++ b/imxyjl/1781 컵라면.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+
+const n = Number(input[0]);
+
+class PQ{
+    constructor(){
+        this.h = [];
+    }
+    size(){
+        return this.h.length;
+    }
+    swap(idx1, idx2){
+        [this.h[idx1], this.h[idx2]] =  [this.h[idx2], this.h[idx1]] 
+    }
+    add(v){
+        this.h.push(v);
+        this.bubbleU();
+    }
+    remove(){
+        if(this.h.length === 0) return null;
+        if(this.h.length ===1) return this.h.pop();
+
+        const toRemove = this.h[0];
+        this.h[0] = this.h.pop();
+        this.bubbleD();
+        return toRemove;
+    }
+    bubbleU(){
+        let curIdx = this.h.length - 1;
+        let pIdx = Math.floor((curIdx-1) /2);
+
+        while(this.h[pIdx] && this.h[curIdx] > this.h[pIdx])
+        {
+            this.swap(curIdx, pIdx);
+            curIdx = pIdx;
+            pIdx =  Math.floor((curIdx-1) /2);
+        }
+    }
+    bubbleD(){
+        let curIdx = 0;
+        let leftIdx = curIdx * 2 +1, rightIdx = curIdx *2 + 2;
+
+        while(
+            (this.h[leftIdx] && this.h[leftIdx] > this.h[curIdx])||
+            (this.h[rightIdx] &&this.h[rightIdx] > this.h[curIdx])
+        ){
+            let biggerIdx = leftIdx;
+            if(this.h[rightIdx] && this.h[rightIdx] > this.h[leftIdx]) biggerIdx = rightIdx;
+
+            this.swap(biggerIdx, curIdx);
+            curIdx = biggerIdx;
+            leftIdx = curIdx * 2 +1, rightIdx = curIdx *2 + 2;
+        }
+    }
+}
+
+const pq = new PQ();
+const assignList = Array.from({length: n+1}, () => []);
+
+for(let i=1; i<input.length; i++){
+    const [dead, cup] = input[i].split(' ').map(Number);
+    assignList[dead].push(cup);
+}
+
+let cupSum = 0;
+
+for(let i=n; i >= 1; i--){
+    assignList[i].forEach(cup => pq.add(cup));
+
+    if(pq.size() === 0) continue;
+    cupSum += pq.remove();
+}
+
+console.log(cupSum);


### PR DESCRIPTION
## 🏷️ 백준번호
- [1781](https://www.acmicpc.net/problem/1781)

## ✏️ 풀이방법
- 포인트: 올바른 그리디 로직을 생각하는 것 
- 왜 틀렸는가? 성급한 그리디
  - 처음에 생각한 방법이 최선이 아닐 거라는 생각을 잠시 했지만, 달리 떠오르는 방법이 없어 일단 구현했다. 그러다보니 사고가 처음 방식에 갇혀버렸음 😞
  - **'현재 시간에서 가장 많은 컵라면을 주는 문제를 선택해야 한다.'** 
  - 뭔가 찜찜했지만...(찜찜했던 이유: 데드라인 의미 헷갈림) 일단 저대로 구현했다. 역시 아니었다. (어쩐지 너무 쉽더라^^)
  - 위 문장은 맞는 말이지만, '현재 시간'이 1초부터 흐르는 순차적인 시간이 아니라 역방향 탐색을 했을 때의 시간이어야 했다.

- 위에서 도출할 수 있는 포인트
  - 앞에서 문제를 풀어버리면 무조건 시간이 하루 흘러간다.  
  - **데드라인은 그 날까지 풀기만 하면 된다는 의미**이다. 
- 따라서 맨 처음에 컵라면을 보이는 족족 가져가버리면, 그 문제를 푸느라 시간이 가버리기 때문에 데드라인이 더 길고 컵라면을 많이 주는 문제를 푸는 기회를 잃을 수 있다. (2보 전진을 위한 1보 후퇴 불가, 그냥 1보만 갈 수 있는 무지성 풀이가 됨)
- 그럼 어떻게 구하지? -> **시간 역순으로 탐색**한다! 
- 맨 앞부터 순서대로 탐색하면 뒤의 시간에서 어떤 숨겨진 최적해가 있을지를 알 수 없다.
- 하지만 시간 역순으로 탐색하면 데드라인은 시작~데드라인이라는, **탐색이 난해한 '구간'이 아니라 말 그대로 딱 떨어지는 시간**이 된다. (구간이 아니라 점이 됨)
- 다시 말해, '어느 시점에서 후보로 등록 가능한지 정확히 알 수 없음'에서 **'이 시점부터 최적 후보로 등록 가능'**으로 처리할 수 있게 된다! 그러므로 이 시점에서 가장 컵라면을 많이 주는 일을 확정할 수 있다. 

## ⏰ 시간복잡도
n개의 데이터를 우선순위 큐에 삽입/삭제함. 따라서 O(nlogn)

## 기타
- 솔직히 풀이 쓰면서도 헷갈렸다;; 지금 실력으로는 처음에 생각한 방식이 최선이 아니라는 것만 확신할 수 있을 것 같고 역방향 탐색.. 어떻게 생각해냈다 하더라도 맞는 그리디인지 확신 못 해서 못 풀었을 확률 100%
- 우선순위 큐는 그리디와 자주 엮이는 듯. 최근 풀었던 문제들은 거진 이런 식이었다. 근데 그리디의 출제 빈도가 낮다면... 가볍게 간단한 그리디+우선순위 큐는 나올 법한데 고난도 문제로는 잘 안 나올 것 같다는 생각
- 무의식적으로 큐에 모든 값을 넣으려 했는데, 꼭 그럴 필요 없다는 것을 인지하게 됨