### PR TITLE
[250303] 쿠키 (진욱이의 농장)

### DIFF
--- a/cookie/1460.js
+++ b/cookie/1460.js
@@ -1,0 +1,84 @@
+const fs = require("fs");
+const [input, ...rest] = fs.readFileSync(0, "utf8").trim().split("\n");
+
+const [n, m] = input.split(" ").map(Number);
+const farms = Array.from({ length: n + 1 }, () => Array.from({ length: n + 1 }).fill(0));
+
+rest.forEach((line) => {
+  let [x, y, l, f] = line.split(" ").map(Number);
+  x++;
+  y++;
+
+  for (let i = x; i < x + l; i++) {
+    for (let j = y; j < y + l; j++) {
+      farms[i][j] = f;
+    }
+  }
+});
+
+const prefixSumBySeed = Array.from({ length: 8 }, () =>
+  Array.from({ length: n + 1 }, () => Array.from({ length: n + 1 }).fill(0))
+);
+
+// 씨앗 별 누적합 구하기
+for (let seed = 0; seed < 8; seed++) {
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= n; j++) {
+      prefixSumBySeed[seed][i][j] =
+        prefixSumBySeed[seed][i][j - 1] +
+        prefixSumBySeed[seed][i - 1][j] -
+        prefixSumBySeed[seed][i - 1][j - 1] +
+        (farms[i][j] === seed ? 1 : 0);
+    }
+  }
+}
+
+// 특정 씨앗의 범위 누적합 구하는 함수
+const getPrefixSumBySeed = (seed, a, b, c, d) => {
+  const sum = prefixSumBySeed[seed];
+  return sum[c][d] - sum[c][b - 1] - sum[a - 1][d] + sum[a - 1][b - 1];
+};
+
+// k * k 최댓값
+let answer = 0;
+
+for (let i = 1; i <= n; i++) {
+  for (let j = 1; j <= n; j++) {
+    // 특정 좌표가 0이라면 스킵
+    if (farms[i][j] === 0) continue;
+
+    let left = 1;
+    let right = n;
+
+    while (left < right) {
+      let mid = Math.floor((left + right + 1) / 2);
+
+      let a = i;
+      let b = j;
+      let c = i + mid - 1;
+      let d = j + mid - 1;
+
+      if (c > n || d > n) {
+        right = mid - 1;
+        continue;
+      }
+
+      if (getPrefixSumBySeed(0, a, b, c, d)) {
+        right = mid - 1;
+        continue;
+      }
+
+      let cnt = 0;
+      for (let seed = 1; seed < 8; seed++) {
+        if (getPrefixSumBySeed(seed, a, b, c, d) > 0) cnt++;
+      }
+
+      if (cnt <= 2) left = mid;
+      else right = mid - 1;
+    }
+
+    answer = Math.max(answer, right * right);
+  }
+}
+
+console.log(answer);


### PR DESCRIPTION
## 🏷️ 백준번호
- [1460](https://www.acmicpc.net/problem/1460)

## ✏️ 풀이방법
누적합 문제로 미리 합을 구해서 시간을 줄이는 문제이다.
시간제한은 2초 => 2 * 10^8이 제한이며, 주어진 N은 10^3으로 O(N^2 log N)까지는 가능하고 N^3부터는 불가능하다고 봐도 된다.

문제는 이차원 배열을 순회하며 정사각형 크기가 1부터 N까지 키워가며 최댓값을 찾아야 한다는 것이 문제이다.
단순 완전탐색으로 돌린다고 하면 O(N^3)으로 누적합으로 더하기 연산을 O(1)로 내려도 시간초과이다.
그래서 1부터 N까지 찾는 과정을 이분탐색을 활용해서 O(logN)으로 내려서 O(N^2 log N)으로 문제를 해결하는 것이 키포인트이다.

### 문제의 조건
- 정사각형을 선정해서 준규가 가져갈 수 있는 최대 넓이를 구한다.
- 정사각형 내에 씨앗의 종류는 최대 2개까지 허용된다.
- 0이 포함되면 안 된다.

### 무슨 누적합을 구해야할까?
처음에는 씨앗(0~7)이 뿌려진 값을 미리 더해서 차를 구하면 개수를 구별할 수 있지 않을까? 시도했지만 어림도 없었다...
그래서 씨앗 0의 누적 개수, 씨앗 1의 누적 개수 ... 씨앗 7의 누적 합을 구해놓고 풀 수 있지 않을까 생각해서, 현재 위치까지의 씨앗 개수를 저장하는 누적합을 구했다.

그리고 특정 위치부터 특정 위치까지의 특정 씨앗이 몇 개 있는지 누적합을 활용한다면, 특정 범위 내에 씨앗이 몇 종류 있는지를 쉽게 확인할 수도 있다.


### 무엇을 이분탐색 해야할까?
내가 원하는 답은 이차원 배열 내에서 특정 정사각형을 골랐을 때 조건에 맞는 최대 칸 개수를 구하는 것이다.
그래서 특정 정사각형 변의 길이를 K로 잡고 1부터 n까지 어떤 K가 최대가 되는지를 검사해야한다.

왼쪽을 1, 오른쪽을 n으로 하고, 가운데를 Math.floor((left + right + 1) / 2)로 잡고 최대가 되는 K를 찾는 것이 목표
이 정보를 활용해서 이차원 배열 순회 i,j를 두고 종료 지점을 left와 right를 늘리고 줄여가며 최대가 되는 개수를 찾는 것이다.

여기서 조건에 따라 배열의 [i][j]가 0이라면 후보가 되지 못 하므로 패스한다.

그리고 끝 점이 n을 초과해버리면 범위 이탈이므로 오른쪽을 mid-1로 조정, 특정 범위 내의 0의 개수가 1개 이상이어도 mid-1로 조정하고 패스한다. (0이 포함되어있다는 의미)

그리고 답의 조건이 된다면, 씨앗을 비교해서 1부터 7까지 종류가 두 개 이하인지 확인되면 조건을 만족하므로 left를 mid로 옮기고 더 큰 값이 있는지 검사하러 간다. 반대로 3개 이상이면 후보가 아니므로 right를 mid-1로 줄여서 범위를 좁힌다.
```js
  let cnt = 0;
  for (let seed = 1; seed < 8; seed++) {
    if (getPrefixSumBySeed(seed, a, b, c, d) > 0) cnt++;
  }

  if (cnt <= 2) left = mid;
  else right = mid - 1;
```

### 누적합을 정복할 때까지
아직.. 누적합 개념이 어렵다. 합을 미리 구해서 시간 복잡도를 줄인다는 개념 자체는 알겠으나, 이를 응용해서 접근하는 방식이 어렵다. 특히 어떤 누적합을 구해 놓아야 할까? 이 관점을 빠르게 파악하고 싶다.


## ⏰ 시간복잡도
2차원 배열을 순회하며 이분탐색을 수행하므로 O(N^2 log N)이다.
