### PR TITLE
[Day17] 올리(부분합, 주사위 굴리기)

### DIFF
--- a/imxyjl/14499 주사위 굴리기.js
+++ b/imxyjl/14499 주사위 굴리기.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+const [n, m, x, y, k] = input[0].split(' ').map(Number);
+
+const bd = input.slice(1, n + 1).map(row => row.split(' ').map(Number));
+const cmd = input[input.length - 1].split(' ').map(Number);
+
+const dice = Array(6).fill(0);
+const DICE_INFO = { front: 0, back: 1, top: 2, bottom: 3, west: 4, east: 5 };
+const CMD_INFO = { north: 3, west: 2, east: 1, south: 4 };
+
+const move = (x, y, cmd) => {
+    switch (cmd) {
+        case CMD_INFO.north: return [x - 1, y];
+        case CMD_INFO.west: return [x, y - 1];
+        case CMD_INFO.east: return [x, y + 1];
+        case CMD_INFO.south: return [x + 1, y];
+    }
+};
+
+const isMoveable = (x, y, cmd) => {
+    switch (cmd) {
+        case CMD_INFO.north: return x - 1 >= 0;
+        case CMD_INFO.west: return y - 1 >= 0;
+        case CMD_INFO.east: return y + 1 < m;
+        case CMD_INFO.south: return x + 1 < n;
+        default: return false;
+    }
+};
+
+const rollDice = (cmd) => {
+    let temp = [...dice]; 
+
+    switch (cmd) {
+        case CMD_INFO.north:
+            dice[DICE_INFO.top] = temp[DICE_INFO.front];
+            dice[DICE_INFO.front] = temp[DICE_INFO.bottom];
+            dice[DICE_INFO.bottom] = temp[DICE_INFO.back];
+            dice[DICE_INFO.back] = temp[DICE_INFO.top];
+            break;
+        case CMD_INFO.south:
+            dice[DICE_INFO.top] = temp[DICE_INFO.back];
+            dice[DICE_INFO.back] = temp[DICE_INFO.bottom];
+            dice[DICE_INFO.bottom] = temp[DICE_INFO.front];
+            dice[DICE_INFO.front] = temp[DICE_INFO.top];
+            break;
+        case CMD_INFO.west:
+            dice[DICE_INFO.top] = temp[DICE_INFO.east];
+            dice[DICE_INFO.east] = temp[DICE_INFO.bottom];
+            dice[DICE_INFO.bottom] = temp[DICE_INFO.west];
+            dice[DICE_INFO.west] = temp[DICE_INFO.top];
+            break;
+        case CMD_INFO.east:
+            dice[DICE_INFO.top] = temp[DICE_INFO.west];
+            dice[DICE_INFO.west] = temp[DICE_INFO.bottom];
+            dice[DICE_INFO.bottom] = temp[DICE_INFO.east];
+            dice[DICE_INFO.east] = temp[DICE_INFO.top];
+            break;
+    }
+};
+
+
+let curX = x, curY = y;
+cmd.forEach(cmd => {
+    if (!isMoveable(curX, curY, cmd)) return;
+
+    rollDice(cmd);
+    [curX, curY] = move(curX, curY, cmd);
+
+    if (bd[curX][curY] === 0) {
+        bd[curX][curY] = dice[DICE_INFO.bottom];
+    } else {
+        dice[DICE_INFO.bottom] = bd[curX][curY];
+        bd[curX][curY] = 0;
+    }
+
+    console.log(dice[DICE_INFO.top]);
+});

--- a/imxyjl/1806 부분합.js
+++ b/imxyjl/1806 부분합.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+
+const [n, s] = input[0].split(' ').map(Number);
+const arr = input[1].split(' ').map(Number);
+
+let startIdx = 0;
+let endIdx = 0;
+
+const ps = Array.from({length: n}, () => 0);
+ps[0] = arr[0];
+for(let i=1; i<arr.length; i++)
+{
+     ps[i] = arr[i] + ps[i-1];
+}
+const calculateSum = (startIdx, endIdx) => {  
+    return ps[endIdx] - (startIdx > 0 ? ps[startIdx - 1] : 0);
+};
+
+let isPossible = false;
+let minLen = arr.length;
+
+while(startIdx < arr.length && endIdx < arr.length){ 
+    if(calculateSum(startIdx, endIdx) >= s){
+        minLen = Math.min(minLen, endIdx-startIdx+1);
+        startIdx++;
+        isPossible = true;
+    }  else{
+        endIdx++;
+    }      
+}
+
+console.log(isPossible? minLen: 0);


### PR DESCRIPTION
## 🏷️ 백준번호
- [14499](https://www.acmicpc.net/problem/14499)
- [1806](https://www.acmicpc.net/problem/1806) 

오늘은 시간복잡도 먼저...ㅎㅎ

## ⏰ 시간복잡도
- 시뮬 -> 딱히 복잡도 따질 필요 없음. 그럴 로직도 없었고 시뮬이라 인풋이 작다. 대충 생각해보면 O(n^2)?
- 부분합 -> 배열 길이 10만, 시간 제한 0.5초임. 브루트포스로 풀면 O(n^2)는 나오는데 그럼 100퍼 시간초과이다.
듣기로는 nlogn이나 n이나 간발의 차로 시초가 나는 경우는 드물다고는 한다. 그러니까 최소 nlogn 시간에는 들어와야 한다.  

## ✏️ 풀이방법
### 주사위 굴리기
문제 이해가 구현보다 훨씬 어려웠다. 주요 풀이 포인트만 정리
- 주사위의 전개도?
  - 괜히 전개도라는 말을 쓴 게 아니었다^^; 펼쳐서 줬길래 이게 지도 상에 이렇게 펼쳐진다는건가? 싶었는데 아니었음. 입체도형을 생각하라는 말이었슴..
- "주사위는 지도 위에 윗 면이 1이고, 동쪽을 바라보는 방향이 3인 상태로 놓여져 있으며"
  - 저 "윗 면"이라는 게 포인트였음... 지도상에 육면체를 올려놨을 때 지도와 맞닿는 부분이 예시의 1번 자리라는 뜻이었다. 즉 주사위의 bottom 
- 주사위가 이동했을 때 마다 상단에 쓰여 있는 값을~
  - 일부러 위의 윗 면과 헷갈리지 말라고 한 건지 상단이라는 표현을 썼다. 근데도 이게 저 바닥면을 말하는건지 진짜 공중을 향하는 윗부분을 말하는 건지 헷갈려서 테케 직접 시뮬레이션 한 다음에야 후자임을 알 수 있었다... 

### 부분합
1. 구간합을 구한다.
2. 투 포인터를 이용해 적은 탐색으로 모든 케이스를 살펴볼 수 있게 한다. 

투 포인터인 이유는 모든 배열 요소에 대해 구간에 대한 합을 조사하면 당연히 시초가 나기 때문이다.
이 문제의 투 포인터 핵심 로직은 조건을 만족하는 값에 도달하지 못했을 때는 계속 탐색을 지속하고(end++), 도달한 경우에는 최적해가 없는지 조사(start++)하는 것이었다. 
dp나 prefix sum때와 달리 여기서는 각 요소(점)를 기준으로 생각하지 말고 **구간(선)을 늘이고 줄이는 방향**으로 생각하면 될 것 같다. 

## 기타
- 시뮬레이션 문제
  - 문제 이해에 시간을 쏟는 것을 두려워하지 않아야 한다. 대충 읽으면 시간 더 걸림
  - 하지만 꼼꼼히 읽었을 때 어느 정도의 시간은 들 수밖에 없음. 그러니까 구현은 정신 바짝 차리고 해야됨 ㅠㅠ 분기 처리가 많아지니 실수할 여지가 더 늘어난다. 그러나 코드 짤 기회는 1번... 실전이었으면 디버깅할 시간이 없을 것 같다.
  - 전개도 펼쳐놓고 사방으로 굴렸을 때의 상태를 only 상상으로만 그렸는데 실수하기 딱 좋을 것 같다. 다른 사람들의 풀이를 찾아보니 육면체를 케이스별로 그리고 각 케이스별 위치를 표시해놨던데, 이것처럼 **그림**을 적극적으로 이용해봐야겠다는 생각이 들었다. 

- 기타
  - 음 일단 이 부분은 대충 구현하고 나중에 답 틀리면 다시 봐야겠다~ -> 안됨~ 모든 단계를 어느 정도는 검증하고 풀어야 디버깅 용의자가 줄어듦. 이게 쌓이면 어디서 틀린건지 감도 안옴
  - **원본 배열**을 연산 중에 바꾸지 않도록 조심... **사본** 만들고 하자...
  - 엣지 케이스 조심! 문풀도 문풀인데 반례 찾는 게 진짜 어려운데... 지금까지 해 본 바로는
    - 말 그대로 엣지인 케이스들 넣어보기. **딱 하나의 입력, 입력이 주어지지 않는 경우, 경계값 입력**(배열 맨 앞, 배열 맨 뒤) 조심
    - 나아가서 어떤 동작들이 맞물리거나, 예제 케이스의 명령 순서를 반대로 해 보는 것도 반례 잡는 데 도움이 되는 듯하다.
    - 값을 줄 때의 팁은 1이나 0으로만 채우거나 그런 작은 수 조합 + 하나의 큰 수 조합으로 내가 계산하기 편한 걸로 하는 게 좋다. 