### PR TITLE
[Day18] 올리(특정한 최단 경로)

### DIFF
--- a/imxyjl/1504 특정한 최단 경로.js
+++ b/imxyjl/1504 특정한 최단 경로.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+const [n, e] = input[0].split(' ').map(Number);
+const adj = Array.from({length: n+1}, () => []);
+
+class PQ{
+    constructor(){
+        this.h = [];
+    }
+    size(){
+        return this.h.length;
+    }
+    swap(idx1, idx2){
+        [this.h[idx1], this.h[idx2]] =   [this.h[idx2], this.h[idx1]]; 
+    }
+    add(v){
+        this.h.push(v);
+        this.bubbleU();
+    }
+    remove(){
+        if(this.h.length === 0) return null;
+        if(this.h.length ===1) return this.h.pop();
+        
+        const toRemove = this.h[0];
+        this.h[0] = this.h.pop();
+        this.bubbleD();
+        return toRemove;
+    }
+    bubbleU(){
+        let curIdx = this.h.length - 1;
+        let pIdx = Math.floor((curIdx-1)/2);
+
+        while(
+            this.h[pIdx] && this.h[pIdx] > this.h[curIdx]
+        ){
+            this.swap(pIdx, curIdx);
+            curIdx = pIdx;
+            pIdx = Math.floor((curIdx-1)/2);
+        }
+    }
+    bubbleD(){
+        let curIdx = 0;
+        let leftIdx = curIdx * 2 + 1, rightIdx = curIdx * 2 + 2;
+        while(
+            (this.h[leftIdx] && this.h[leftIdx] < this.h[curIdx]) ||
+            (this.h[rightIdx] && this.h[rightIdx] < this.h[curIdx])
+        ){
+            let smallerIdx= leftIdx;
+            if(this.h[rightIdx] && this.h[rightIdx] < this.h[smallerIdx]) smallerIdx = rightIdx;
+
+            this.swap(smallerIdx, curIdx);
+            curIdx = smallerIdx;
+            leftIdx = curIdx * 2 + 1, rightIdx = curIdx * 2 + 2;
+        }
+    }
+}
+
+const getDis = (startV, endV) =>{
+    const pq = new PQ();
+    const dist = Array.from({length: n+1}, () => Infinity); // 조심!
+    
+    dist[startV] = 0;
+    pq.add([startV, dist[startV]]);
+
+    while(pq.size() >0){
+        const [curV, curW] = pq.remove();
+        if(dist[curV] !== curW) continue;
+        
+        adj[curV].forEach(v =>{
+            const [nextV, nextW] = v;
+            const tmpW = nextW + dist[curV];
+            if(tmpW >= dist[nextV]) return;
+
+            dist[nextV] = tmpW;
+            pq.add([nextV, dist[nextV]]);
+        });
+    } 
+    return dist[endV] // 이게 포인트!
+};
+
+for(let i=1; i<input.length -1; i++){
+    const [u, v, w] = input[i].split(' ').map(Number);
+    adj[u].push([v, w]);
+    adj[v].push([u, w]);
+}
+
+const [v1, v2] = input[input.length-1].split(' ').map(Number);
+const v1Dist = getDis(1, v1) + getDis(v1, v2) + getDis(v2, n);
+const v2Dist = getDis(1, v2) + getDis(v1, v2) + getDis(v1, n); // v1~v2는 무향이라 사실상 같음
+const min = Math.min(v1Dist, v2Dist);
+
+console.log(min >= Infinity ? -1 : min);


### PR DESCRIPTION
## 🏷️ 백준번호
- [1504](https://www.acmicpc.net/problem/1504)
- 등교한 날은 간단하게 흑흑

## ✏️ 풀이방법
정점을 고정시켜두고 다익스트라를 돌려 각 구간의 가중치를 구하고 나중에 전부 더한다.
한 구간이 탐색이 불가능하면 어떻게 처리할까 싶었는데 어차피 Infinity로 가중치를 초기화하니까, 합이 Infinity보다 같거나 크면 전체 경로 탐색에 실패한 것으로 간주하면 됐다.

처음에 조금 헷갈렸던 게, 어떤 구간구간의 최단거리가 전체 구간의 최단거리임을 보장해줄 수 없다는 거였다.
예를 들어 A ->...  B ->...  C -> ... D인 경로에서, A->C의 최단거리가 A->D 최단거리의 일부라고 할 수 없다. 
그런데 이 문제에서는 아예 특정 정점을 지나야만 한다고 못박아뒀으니 위의 사실은 상관 없다. 

## ⏰ 시간복잡도
다익스트라를 여러 번 실행하기는 하지만, 항상 상수 시간(6회)에 불과하므로 O(ElogV)

## 기타
오답 포인트...
- 무향인지 유향인지 잘 읽고 adj를 만들 것!
- 초기화가 필요한 값들을 전역에 선언하지 말자
