### PR TITLE
[Day20] 올리(🐜 기적의 매매법 🐜)

### DIFF
--- a/imxyjl/20546 🐜 기적의 매매법 🐜.js
+++ b/imxyjl/20546 🐜 기적의 매매법 🐜.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+
+const money = Number(input[0]);
+const rateList = input[1].split(' ').map(Number);
+
+const jun = () =>{
+    let curMoney = money;
+    let stockCount = 0;
+
+    rateList.forEach((rate)=>{
+        const gainable = stockCount * rate;
+
+        if(curMoney + gainable >= rate){
+            curMoney += gainable;
+            stockCount = 0;
+        }
+        while(curMoney >= rate){
+            curMoney -= rate;
+            stockCount++;
+        }
+    });
+    return curMoney + rateList.at(-1) * stockCount;
+};
+
+const sung = () =>{
+     let curMoney = money;
+    let stockCount = 0;
+
+    const getState = (idx) =>{
+        if(rateList[idx-1] === rateList[idx]) return 0;
+        
+        if(rateList[idx-2] < rateList[idx-1] && rateList[idx-1] < rateList[idx]) return 1;
+        else if(rateList[idx-2] > rateList[idx-1] && rateList[idx-1] > rateList[idx]) return -1;
+        else return 0;
+    }
+
+    for(let i=3; i<rateList.length; i++){
+        const state = getState(i-1);
+        if(state === 1 && stockCount > 0){ // 매도 
+            curMoney += rateList[i] * stockCount;
+            stockCount = 0;
+        }
+        if(state===-1){ // 매수
+            while(curMoney >= rateList[i]){
+                curMoney -= rateList[i];
+                stockCount++
+            }
+        }
+    }
+
+    return curMoney + stockCount * rateList.at(-1);
+};
+
+const Sung = sung();
+const Jun = jun();
+if(Sung === Jun) console.log("SAMESAME");
+if(Sung > Jun) console.log("TIMING");
+if(Sung < Jun) console.log("BNP");


### PR DESCRIPTION
## 🏷️ 백준번호
- [20546](https://www.acmicpc.net/problem/20546)

## ✏️ 풀이방법
문제를 잘 읽는다. (ㅋㅋ)

이 문제 해결의 키포인트는 크게 3가지라고 생각한다.
> 1. 주식을 살 수 있다면 무조건 최대한 많이 산다. 준현이는 욕심쟁이이기 때문에, 주식을 살 수 있다면 가능한 만큼 즉시 매수한다 

첫 번째 사람은 있는 주식을 팔아서 현금화한 뒤 매수한다.

> 2. 현재 가지고 있는 현금이 100원이고 주가가 11원이라면 99원어치의 주식을 매수하는 것이다.

두 번째 사람은 현금만을 기준으로 주식을 산다. 

> 3. 3일 연속 가격이 전일 대비 상승하는 주식은 다음날 무조건 가격이 하락한다고 가정한다. 따라서 **현재 소유한 주식의 가격이 3일째 상승한다면, 전량 매도**한다. **전일과 오늘의 주가가 동일하다면 가격이 상승한 것이 아니다.**
3일 연속 가격이 전일 대비 하락하는 주식은 다음날 무조건 가격이 상승한다고 가정한다. 따라서 이러한 경향이 나타나면 **즉시 주식을 전량 매수**한다. 전일과 오늘의 주가가 동일하다면 가격이 하락한 것이 아니다.

  - "즉시"라고 하길래, 3일차에 연속 기조가 확인되면 바로 매수/매도하는 줄 알았다.
  - 근데 4일차에 하는 거였음;;
  - 첫 번째 사람의 예시는 친절하게 표로 주어지는데, 두 번째 사람은 줄글 설명만 있다. 
  - 다행히 이번 문제에서는 **주어진 테스트케이스에서 위 조건을 사용하지 않으면 틀린 답**이 나왔다. 하지만 아니었다면 맞왜틀 시작이었을 듯...ㅋㅠ
  - 이제 보니 매도 설명에서는 "즉시"라는 말이 없는데, 매수에서는 있다. 그런데 둘 다 4일차에 처리해줘야 하는 게 맞다. 

## ⏰ 시간복잡도
단순 순회 O(n)

## 기타
이 문제는 설명을 이상하게 한 것 같지는 않다. 나라면 즉시라는 표현을 쓰지 않았겠지만... 일부러 살짝 모호하게 출제한 것 같기도 하다. 근데 3연속 기조가 있고 난 바로 뒤에 <- 라고도 충분히 해석할 수 있는 느낌이다.
하지만 왜 즉시를 한 쪽에만 썼는지는 이해할 수 없다...

근데 아까 풀었던 지뢰찾기 문제는 설명이 에바라는 생각이 든다...
이쯤되면 내가 지문에 너무 집착하는 것 같기도 하다. 그래도 설명을 잘 해줘야 하는 거 아냐?!
출제자들이 거진 숫자놀이 좋아하는 이과생들이라 그런지 줄글 설명을 너무 믿으면 안 된다는 생각이 요즘 든다. **글은 적당히 참고만 하고(ㅋㅋ) 테스트케이스/예제로 문제를 잘 이해했는지 검증**하는 게 더 정확도가 높은 듯