### PR TITLE
[Day22] 올리(Puyo Puyo)

### DIFF
--- a/imxyjl/11559 Puyo Puyo.js
+++ b/imxyjl/11559 Puyo Puyo.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const bd = fs.readFileSync(0, 'utf-8').trim().split('\n').map(row => row.split(''));  // 문자 배열로 변환
+
+let totalCount = 0;
+const dx = [1, 0, -1, 0];
+const dy = [0, 1, 0, -1];
+
+// 뿌요를 아래로 내리는 함수
+const gravity = () => {
+    for (let y = 0; y < 6; y++) { // 각 열을 기준으로 진행
+        for (let x = 10; x >= 0; x--) {  // 위에서 아래로 순회하면서 이동
+            if (bd[x][y] !== '.' && bd[x + 1][y] === '.') {
+                let nx = x;
+                while (nx + 1 < 12 && bd[nx + 1][y] === '.') {
+                    bd[nx + 1][y] = bd[nx][y];
+                    bd[nx][y] = '.';
+                    nx++;
+                }
+            }
+        }
+    }
+};
+
+
+// 현재 탐색 대상에 인접한 뿌요의 좌표 조사
+const bfs = (startX, startY, vis) => {
+    const visPos = [[startX, startY]];
+    const q = [[startX, startY]];
+    const color = bd[startX][startY];
+
+    vis[startX][startY] = true;
+
+    while (q.length > 0) {
+        const [curX, curY] = q.shift();
+
+        for (let dir = 0; dir < 4; dir++) {
+            const nx = curX + dx[dir];
+            const ny = curY + dy[dir];
+
+            if (nx >= 12 || nx < 0 || ny >= 6 || ny < 0) continue;
+            if (bd[nx][ny] === '.' || bd[nx][ny] !== color || vis[nx][ny]) continue;
+
+            q.push([nx, ny]);
+            visPos.push([nx, ny]);
+            vis[nx][ny] = true;
+        }
+    }
+    return visPos;
+};
+
+while (true) {
+    const vis = Array.from({ length: 12 }, () => Array(6).fill(false));
+    let isBomb = false;
+    let toRemove = [];
+
+    for (let i = 0; i < 12; i++) {
+        for (let k = 0; k < 6; k++) {
+            if (bd[i][k] !== '.' && !vis[i][k]) {
+                const curVisPos = bfs(i, k, vis);
+                if (curVisPos.length >= 4) {
+                    isBomb = true;
+                    toRemove.push(...curVisPos);
+                }
+            }
+        }
+    }
+  
+    toRemove.forEach(([x, y]) => bd[x][y] = '.');
+
+    gravity();
+
+    if (!isBomb) break;
+    else totalCount++;
+}
+console.log(totalCount);


### PR DESCRIPTION
## 🏷️ 백준번호
- [11559](https://www.acmicpc.net/problem/11559)

## ✏️ 풀이방법
- **이번 턴에 터질 수 있는 뿌요 찾기**
  - BFS를 사용해 터질 수 있는 뿌요를 탐색한다.
    - BFS를 잘 돌려야 함. 이게 1차 난관
    - **방문 배열 초기화를 매 턴마다** 해 줘야 한다. 
    - 일단 가능한 모든 칸을 검사하되 이미 방문했던 칸이면 추가 bfs를 시도하지 않음
    - 조건을 만족하면 bfs를 돌고 방문한 칸의 좌표 배열을 리턴한다.
    - 이때, **결과를 보고 방문한 칸이 4개 이상일 때만 해당 턴에서 지울 뿌요 좌표에 추가**해준다.
- 터지는 뿌요를 모두 터트리기(`.`로 만들기)
- **남은 뿌요들을 아래로 내리기**
  - 뿌요를 삭제함에 따라 위에 붕 떠있게 되는 뿌요들을 전부 아래로 내려줘야 한다. 이게 2차 난관
    - 자신은 뿌요인데 아래가 빈 공간이라면 내려가야 한다.
    - 이때 뿌요를 얼마나 내려야 하는지는 매번 탐색을 해야 함 -> 그냥 **모든 칸을 검사**하는 게 제일 정확하다. 
    - 그러기 위해서는 그냥 한 줄(열)마다 while문으로 탐색한다. 우선순위 큐 구현할 때 인덱스 스위칭하는 것마냥 let을 이용해서 스왑했다. 


## ⏰ 시간복잡도
O((NM)^2)
입력이 작긴 해도 bfs가 제곱으로 들어가버려서 처음엔 더 최적화해야하나? 로 고민했으나... 상관없었다. 
O(5184)임. GPT 왈 이정도면 상수 수준이라고;;

## 기타
한 단계씩 차근차근 하자... 
1,2단계가 애매한 상황에서 냅다 중력(3)을 구현하니까 이상하게 구현했음