### PR TITLE
[Day25] 올리(스택 수열)

### DIFF
--- a/imxyjl/1874 스택 수열.js
+++ b/imxyjl/1874 스택 수열.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const input = fs.readFileSync(0, 'utf-8').trim().split('\n');
+const n = Number(input[0]);
+const arr = input.slice(1).map(Number);
+
+let cur = 0;
+const ans = [];
+const stack = [];
+
+const play = () => {
+    for (let i = 0; i < arr.length; i++) {
+        while (cur < arr[i]) {
+            stack.push(++cur);
+            ans.push('+');
+        }
+
+        if (stack.length === 0 || stack.at(-1) !== arr[i]) {
+            return false; 
+        }
+
+        stack.pop();
+        ans.push('-');
+    }
+    return true;
+};
+
+if (!play()) console.log("NO");
+else console.log(ans.join('\n'));


### PR DESCRIPTION
## 🏷️ 백준번호
- [1874](https://www.acmicpc.net/problem/1874)

## ✏️ 풀이방법
**push는 항상 오름차순으로 이루어져야 한다**가 포인트!
- 일단 현재 처리해야 하는 수보다 count가 작으면 증가시키면서 스택에 넣는다.
- 이제 pop을 할 차례인데, 스택이 비어 있거나 스택의 top이 현재 처리해야 하는 수와 다르면 실패로 처리한다. 
  - 스택에 push하려면 무조건 오름차순이어야 하고, pop 이전에 push를 통해 현재 탐색하는 수를 넣어둔(혹은 넣어뒀던) 상태이기 때문에 push 이후 top은 무조건 현재 탐색하는 수와 같아야 한다. 아니면 항상 false임
- 이게 다인데.. pop에서도 while문을 써야 하는 걸로 착각해서 괜히 어렵게 돌아갔다. 
  - 부등호로 따지면 top < arr[i]일 때 실패이다. 한번 스택에서 빠진 값들은 다시 넣을 수 없는데, 탐색 대상인 수가 top보다 크다는 것은 기존에 들어왔다가 빠졌음을 의미하기 때문
- 그리고 top이 현재 처리해야 하는 수와 다르기만 하면 무조건 실패인데, 괜히 더 클 때인가 더 작을 때인가~를 신경쓰다가 더 어렵게 풀고 말았다...

## ⏰ 시간복잡도
O(n)

## 기타 
여전히 너무 많은 케이스를 처리하려는 경향이 있다... 특히 스택류 문제에서...
그냥 **예제에 충실하게 기본을 구현하고 나중에 엣지케이스 따로 생각**하는 게 더 효율적인 것 같다. 
